### PR TITLE
[FA-101] Parameterising service name and prompt

### DIFF
--- a/sre_agent/client/client.py
+++ b/sre_agent/client/client.py
@@ -188,7 +188,7 @@ app: FastAPI = FastAPI(
 )
 
 
-@app.get("/diagnose")
+@app.post("/diagnose")
 async def diagnose(
     service: str = "cartservice",
     prompt: str = PROMPT,


### PR DESCRIPTION
This PR parameterises the service name and prompt for the agent.

The `service` and `prompt` can now be inputted as queries when calling the `/diagnose` endpoint.

### What
An update to the `/diagnose` endpoint to include query params for service and prompt.

### Why

So that prompts can be adjusted without needing to rebuild.

### How

### Extra

The `/diagnose` endpoint is now `POST` not a `GET`, seemed to make more semantic sense to be a `POST`.

## Checklist

Please ensure you have done the following:

* [x] I have run application tests ensuring nothing has broken.
* [x] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Make sure to update label on right hand panel.

## MacOS tests

To trigger the CI to run on a macOS backed workflow, add the `macos-ci-test` label to the pull request (PR).

Our advice is to only run this workflow when testing the compatability between operating systems for a change that you've made, e.g., adding a new dependency to the virtual environment.

> Note: This can take up to 5 minutes to run. This workflow costs x10 more than a Linux-based workflow, use at discretion.
