### PR TITLE
[FA-100] Add tool error handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An SRE agent that can monitor application and infrastructure logs, diagnose issu
     - `ANTHROPIC_API_KEY`: An Anthropic API key for making tool requests.
     - `DEV_BEARER_TOKEN`: A password for developers to directly invoke the agent through the `/diagnose` endpoint.
     - `SLACK_SIGNING_SECRET`: The signing secret for the Slack `sre-agent`.
-    - `TOOLS`: '["list_pods", "get_logs", "get_file_contents", "slack_post_requests"]'
+    - `TOOLS`: '["list_pods", "get_logs", "get_file_contents", "slack_post_message"]'
     - `AWS_ACCOUNT_ID` (Optional): The AWS account ID that stores the images. Only required if pulling images from ECR.
 
 ### Prerequisites

--- a/sre_agent/client/utils/schemas.py
+++ b/sre_agent/client/utils/schemas.py
@@ -61,8 +61,9 @@ class ClientConfig:
     tools: list[str] = field(
         default_factory=lambda: json.loads(os.getenv("TOOLS", "[]"))
     )
-    model: str = "claude-3-5-sonnet-latest"
+    model: str = "claude-3-7-sonnet-latest"
     max_tokens: int = 1000
+    max_tool_retries: int = 3
 
     def __post_init__(self) -> None:
         """A post-constructor method for the dataclass."""


### PR DESCRIPTION


### What
Capture and pass errors from tools back to the LLM. 
Check whether the number of retries is not exceeded. 
Finish request after Slack message is sent.

### Why

We do not want the agent to fail silently, when it called a tool incorrectly.

### How

Catch exceptions and pass the error messages to the chat log

### Extra

_If new dependencies are introduced to the project, please list them here:_

* _new dependency_

## Checklist

Please ensure you have done the following:

* [ ] I have run application tests ensuring nothing has broken.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Make sure to update label on right hand panel.

## MacOS tests

To trigger the CI to run on a macOS backed workflow, add the `macos-ci-test` label to the pull request (PR).

Our advice is to only run this workflow when testing the compatability between operating systems for a change that you've made, e.g., adding a new dependency to the virtual environment.

> Note: This can take up to 5 minutes to run. This workflow costs x10 more than a Linux-based workflow, use at discretion.
