### PR TITLE
[FA-103] Add prompt caching to the agent

### DIFF
--- a/sre_agent/client/client.py
+++ b/sre_agent/client/client.py
@@ -91,6 +91,14 @@ class MCPClient:
     def _convert_tool_result_to_text_blocks(
         self, result: str | list[TextContent]
     ) -> list[TextBlockParam]:
+        """Convert a tool result to a list of text blocks.
+
+        Args:
+            result: The result to convert to a list of text blocks.
+
+        Returns:
+            The list of text blocks.
+        """
         blocks = []
         if isinstance(result, str):
             blocks = [TextBlockParam(text=result, type="text")]
@@ -107,6 +115,14 @@ class MCPClient:
         return blocks
 
     def _remove_cache_control(self, messages: list[MessageParam]) -> list[MessageParam]:
+        """Remove the cache control from the messages.
+
+        Args:
+            messages: The list of messages to remove the cache control from.
+
+        Returns:
+            The list of messages with the cache control removed.
+        """
         for message in messages[::-1]:
             if isinstance(message["content"], str):
                 continue
@@ -180,11 +196,11 @@ class MCPClient:
             if hasattr(response, "usage"):
                 total_input_tokens += response.usage.input_tokens
                 total_output_tokens += response.usage.output_tokens
-                if response.usage.cache_creation_input_tokens is not None:
+                if response.usage.cache_creation_input_tokens:
                     total_cache_creation_tokens += (
                         response.usage.cache_creation_input_tokens
                     )
-                if response.usage.cache_read_input_tokens is not None:
+                if response.usage.cache_read_input_tokens:
                     total_cache_read_tokens += response.usage.cache_read_input_tokens
                 logger.info(
                     f"Token usage - Input: {response.usage.input_tokens}, "


### PR DESCRIPTION
Add tools caching.
Add conversation caching (by attaching cache control to the last message every time). Track how many tokens are used in cache creation and reading.
![image](https://github.com/user-attachments/assets/36c53c33-2090-4edf-b4a0-611e944bb257)

### What

This PR implements caching mechanisms for both tools and conversations in the SRE Agent client. It adds token usage tracking for cache operations and introduces cache control to messages.

###Why

* Improve costs by reducing redundant API calls through caching

###How

* Added tool caching by attaching cache control to the last available tool
* Implemented conversation caching by adding cache control to the last message in each conversation
* Added new token usage tracking metrics:
  * Cache creation tokens
  * Cache read tokens
* Modified message handling to support cache control:
  * Added _convert_tool_result_to_text_blocks method to handle cache control
  * Added _remove_cache_control method to clean up cache control before new tool calls
* Updated token usage logging to include cache-related metrics

### Extra

_If new dependencies are introduced to the project, please list them here:_

* _new dependency_

## Checklist

Please ensure you have done the following:

* [ ] I have run application tests ensuring nothing has broken.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Make sure to update label on right hand panel.

## MacOS tests

To trigger the CI to run on a macOS backed workflow, add the `macos-ci-test` label to the pull request (PR).

Our advice is to only run this workflow when testing the compatability between operating systems for a change that you've made, e.g., adding a new dependency to the virtual environment.

> Note: This can take up to 5 minutes to run. This workflow costs x10 more than a Linux-based workflow, use at discretion.
