### PR TITLE
Fixing curl command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ See the [kubernetes-deployment.md](/docs/kubernetes-deployment.md) page for inst
 The fully orchestrated SRE Agent can be deployed with Docker Compose which spins up all of the required servers (Slack, Github, and K8s MCP servers) and an orchestration service which is a proxy between the LLM and the servers, this is the client in the context of MCP. Once the agent has been spun up you can trigger the SRE agent with the following request:
 
 ```
-http://localhost:8003/diagnose?service=<service> \
--H 'accept: application/json' \
--H 'Authorization: Bearer <token>'
+http://localhost:8003/diagnose \
+-H "accept: application/json" \
+-H "Authorization: Bearer <token>" \
+-d "text=<service>"
 ```
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See the [kubernetes-deployment.md](/docs/kubernetes-deployment.md) page for inst
 The fully orchestrated SRE Agent can be deployed with Docker Compose which spins up all of the required servers (Slack, Github, and K8s MCP servers) and an orchestration service which is a proxy between the LLM and the servers, this is the client in the context of MCP. Once the agent has been spun up you can trigger the SRE agent with the following request:
 
 ```
-http://localhost:8003/diagnose \
+curl -X POST http://localhost:8003/diagnose \
   -H "accept: application/json" \
   -H "Authorization: Bearer <token>" \
   -d "text=<service>"

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ The fully orchestrated SRE Agent can be deployed with Docker Compose which spins
 
 ```
 http://localhost:8003/diagnose \
--H "accept: application/json" \
--H "Authorization: Bearer <token>" \
--d "text=<service>"
+  -H "accept: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d "text=<service>"
 ```
 
 ### Prerequisites

--- a/docs/kubernetes-deployment.md
+++ b/docs/kubernetes-deployment.md
@@ -3,7 +3,7 @@
 This page contains the steps to deploy the MCP servers and MCP client onto Kubernetes with an exposed LoadBalancer endpoint.
 
 > [!WARNING]
-> This deployment is not yet "production-ready" and uses transports the bearer token through HTTP which is not secure.
+> This deployment is not yet "production-ready" and transports the bearer token through HTTP which is not secure.
 
 ## Pre-requisites
 
@@ -203,7 +203,8 @@ and find the IP under EXTERNAL-IP.
 Then post your request to the diagnose endpoint on the SRE client service containing the bearer token to authorise the request:
 
 ```
-http://<EXTERNAL-IP>/diagnose?service=<service> \
+http://<EXTERNAL-IP>/diagnose \
 -H 'accept: application/json' \
 -H 'Authorization: Bearer <token>'
+-d "text=<service>"
 ```

--- a/docs/kubernetes-deployment.md
+++ b/docs/kubernetes-deployment.md
@@ -203,7 +203,7 @@ and find the IP under EXTERNAL-IP.
 Then post your request to the diagnose endpoint on the SRE client service containing the bearer token to authorise the request:
 
 ```
-http://<EXTERNAL-IP>/diagnose \
+curl -X POST http://<EXTERNAL-IP>/diagnose \
 -H 'accept: application/json' \
 -H 'Authorization: Bearer <token>'
 -d "text=<service>"


### PR DESCRIPTION
This PR fixes the curl request in the main README which was broken after the last change to the endpoint. 

### What

An updated README

### Why

Fixes broken README command

### How

### Extra

_If new dependencies are introduced to the project, please list them here:_

* _new dependency_

## Checklist

Please ensure you have done the following:

* [x] I have run application tests ensuring nothing has broken.
* [x] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Make sure to update label on right hand panel.

## MacOS tests

To trigger the CI to run on a macOS backed workflow, add the `macos-ci-test` label to the pull request (PR).

Our advice is to only run this workflow when testing the compatability between operating systems for a change that you've made, e.g., adding a new dependency to the virtual environment.

> Note: This can take up to 5 minutes to run. This workflow costs x10 more than a Linux-based workflow, use at discretion.
