### PR TITLE
[FA-137] Paramaterising org name and repo name

### DIFF
--- a/compose.ecr.yaml
+++ b/compose.ecr.yaml
@@ -20,6 +20,10 @@ services:
       - TRANSPORT=SSE
   prompt_server:
     image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/mcp/prompt-server:latest
+    environment:
+      - GITHUB_ORGANISATION=fuzzylabs
+      - GITHUB_REPO_NAME=microservices-demo
+      - PROJECT_ROOT=src
   orchestrator:
     image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/mcp/sre-orchestrator:latest
     ports:

--- a/compose.yaml
+++ b/compose.yaml
@@ -31,6 +31,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.prompt_server
+    environment:
+      - GITHUB_ORGANISATION=fuzzylabs
+      - GITHUB_REPO_NAME=microservices-demo
+      - PROJECT_ROOT=src
 
   orchestrator:
     build:

--- a/k8s/mcp-prompt-server.yaml
+++ b/k8s/mcp-prompt-server.yaml
@@ -21,6 +21,13 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 3001
+          env:
+            - name: GITHUB_ORGANISATION
+              value: "fuzzylabs"
+            - name: GITHUB_REPO_NAME
+              value: "microservices-demo"
+            - name: PROJECT_ROOT
+              value: "src"
 ---
 apiVersion: v1
 kind: Service

--- a/sre_agent/servers/prompt_server/server.py
+++ b/sre_agent/servers/prompt_server/server.py
@@ -1,42 +1,12 @@
 """A server containing a prompt to trigger the agent."""
 
-import os
-from dataclasses import dataclass, fields
 from functools import lru_cache
-from typing import TYPE_CHECKING
 
-from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
-
-if TYPE_CHECKING:
-    from _typeshed import DataclassInstance
+from utils.schemas import PromptServerConfig  # type: ignore
 
 mcp = FastMCP("sre-agent-prompt")
 mcp.settings.port = 3001
-
-load_dotenv()
-
-
-def _validate_fields(self: DataclassInstance) -> None:
-    for config in fields(self):
-        attr = getattr(self, config.name)
-
-        if not attr:
-            msg = f"Environment variable {config.name.upper()} is not set."
-            raise ValueError(msg)
-
-
-@dataclass(frozen=True)
-class PromptServerConfig:
-    """A config class containing Github org and repo name environment variables."""
-
-    organisation: str = os.getenv("GITHUB_ORGANISATION", "")
-    repo_name: str = os.getenv("GITHUB_REPO_NAME", "")
-    project_root: str = os.getenv("PROJECT_ROOT", "")
-
-    def __post_init__(self) -> None:
-        """A post-constructor method for the dataclass."""
-        _validate_fields(self)
 
 
 @lru_cache

--- a/sre_agent/servers/prompt_server/server.py
+++ b/sre_agent/servers/prompt_server/server.py
@@ -1,9 +1,47 @@
 """A server containing a prompt to trigger the agent."""
 
+import os
+from dataclasses import dataclass, fields
+from functools import lru_cache
+from typing import TYPE_CHECKING
+
+from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
+
+if TYPE_CHECKING:
+    from _typeshed import DataclassInstance
 
 mcp = FastMCP("sre-agent-prompt")
 mcp.settings.port = 3001
+
+load_dotenv()
+
+
+def _validate_fields(self: DataclassInstance) -> None:
+    for config in fields(self):
+        attr = getattr(self, config.name)
+
+        if not attr:
+            msg = f"Environment variable {config.name.upper()} is not set."
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class PromptServerConfig:
+    """A config class containing Github org and repo name environment variables."""
+
+    organisation: str = os.getenv("GITHUB_ORGANISATION", "")
+    repo_name: str = os.getenv("GITHUB_REPO_NAME", "")
+    project_root: str = os.getenv("PROJECT_ROOT", "")
+
+    def __post_init__(self) -> None:
+        """A post-constructor method for the dataclass."""
+        _validate_fields(self)
+
+
+@lru_cache
+def _get_prompt_server_config() -> PromptServerConfig:
+    return PromptServerConfig()
 
 
 @mcp.prompt()
@@ -13,10 +51,11 @@ def diagnose(service: str, channel_id: str) -> str:
     {service} service, I only want you to check the pods logs, look up only the 1000
     most recent logs. Feel free to scroll up until you find relevant errors that
     contain reference to a file, once you have these errors and the file name, get the
-    file contents of the path src for the repository microservices-demo in the
-    organisation fuzzylabs. Keep listing the directories until you find the file name
-    and then get the contents of the file. Once you have diagnosed the error please
-    report this to the following slack channel: {channel_id}."""
+    file contents of the path {_get_prompt_server_config().project_root} for the
+    repository {_get_prompt_server_config().repo_name} in the organisation
+    {_get_prompt_server_config().organisation}. Keep listing the directories until you
+    find the file name and then get the contents of the file. Once you have diagnosed
+    the error please report this to the following slack channel: {channel_id}."""
 
 
 if __name__ == "__main__":

--- a/sre_agent/servers/prompt_server/utils/schemas.py
+++ b/sre_agent/servers/prompt_server/utils/schemas.py
@@ -1,0 +1,37 @@
+"""A module containing schemas for the prompt server."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, fields
+from typing import TYPE_CHECKING
+
+from dotenv import load_dotenv
+
+if TYPE_CHECKING:
+    from _typeshed import DataclassInstance
+
+
+load_dotenv()
+
+
+def _validate_fields(self: DataclassInstance) -> None:
+    for config in fields(self):
+        attr = getattr(self, config.name)
+
+        if not attr:
+            msg = f"Environment variable {config.name.upper()} is not set."
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class PromptServerConfig:
+    """A config class containing Github org and repo name environment variables."""
+
+    organisation: str = os.getenv("GITHUB_ORGANISATION", "")
+    repo_name: str = os.getenv("GITHUB_REPO_NAME", "")
+    project_root: str = os.getenv("PROJECT_ROOT", "")
+
+    def __post_init__(self) -> None:
+        """A post-constructor method for the dataclass."""
+        _validate_fields(self)


### PR DESCRIPTION
This PR adds env vars for `GITHUB_ORGANISATION`, `GITHUB_REPO_NAME` and `PROJECT_ROOT` to be set within the prompt server.

### What

Parameterisation of GitHub configurations as environment variables.

### Why

Previously these were not parameterised and so a user would have to adapt the prompt themselves if they wanted to use the project themselves.

### How

Added a config class that reads the env vars and sets them in the prompt.

### Extra

## Checklist

Please ensure you have done the following:

* [x] I have run application tests ensuring nothing has broken.
* [x] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Make sure to update label on right hand panel.

## MacOS tests

To trigger the CI to run on a macOS backed workflow, add the `macos-ci-test` label to the pull request (PR).

Our advice is to only run this workflow when testing the compatability between operating systems for a change that you've made, e.g., adding a new dependency to the virtual environment.

> Note: This can take up to 5 minutes to run. This workflow costs x10 more than a Linux-based workflow, use at discretion.

#45 
