### PR TITLE
[FA-99] Add /health Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,7 @@ This will kick off the diagnostic process using the connected Slack, GitHub, and
 
 Once the agent has finished, you should receive a response in the Slack channel you configured in your `.env` file under `CHANNEL_ID`.
 
-### Checking Service Health
-
+<details>
 A `/health` endpoint is available on the orchestrator service to check its status and the connectivity to its dependent MCP servers. This is useful for liveness/readiness probes or for debugging connection issues.
 
 To check the health, run:
@@ -184,6 +183,7 @@ curl -X GET http://localhost:8003/health
 
 *   A `200 OK` response indicates the orchestrator has successfully connected to all required MCP servers and they are responsive. The response body will list the healthy connected servers.
 *   A `503 Service Unavailable` response indicates an issue, either with the orchestrator's initialisation or with one or more MCP server connections. The response body will contain details about the failure.
+</details>
 
 # Running the agent on AWS
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ This will kick off the diagnostic process using the connected Slack, GitHub, and
 Once the agent has finished, you should receive a response in the Slack channel you configured in your `.env` file under `CHANNEL_ID`.
 
 <details>
+<summary>:warning: Checking Service Health</summary>
 A `/health` endpoint is available on the orchestrator service to check its status and the connectivity to its dependent MCP servers. This is useful for liveness/readiness probes or for debugging connection issues.
 
 To check the health, run:

--- a/README.md
+++ b/README.md
@@ -172,6 +172,19 @@ This will kick off the diagnostic process using the connected Slack, GitHub, and
 
 Once the agent has finished, you should receive a response in the Slack channel you configured in your `.env` file under `CHANNEL_ID`.
 
+### Checking Service Health
+
+A `/health` endpoint is available on the orchestrator service to check its status and the connectivity to its dependent MCP servers. This is useful for liveness/readiness probes or for debugging connection issues.
+
+To check the health, run:
+
+```bash
+curl -X GET http://localhost:8003/health
+```
+
+*   A `200 OK` response indicates the orchestrator has successfully connected to all required MCP servers and they are responsive. The response body will list the healthy connected servers.
+*   A `503 Service Unavailable` response indicates an issue, either with the orchestrator's initialisation or with one or more MCP server connections. The response body will contain details about the failure.
+
 # Running the agent on AWS
 
 ## Deploy Agent on Amazon Elastic Kubernetes Services (EKS)

--- a/compose.ecr.yaml
+++ b/compose.ecr.yaml
@@ -5,6 +5,11 @@ services:
       - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}
       - SLACK_TEAM_ID=${SLACK_TEAM_ID}
       - TRANSPORT=SSE
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "3001"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
   kubernetes:
     image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/mcp/kubernetes:latest
     volumes:
@@ -13,17 +18,32 @@ services:
       - TRANSPORT=SSE
       - AWS_REGION=${AWS_REGION}
       - TARGET_EKS_CLUSTER_NAME=no-loafers-for-you
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "3001"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
   github:
     image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/mcp/github:latest
     environment:
       - GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN}
       - TRANSPORT=SSE
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "3001"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
   prompt_server:
     image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/mcp/prompt-server:latest
     environment:
       - GITHUB_ORGANISATION=fuzzylabs
       - GITHUB_REPO_NAME=microservices-demo
       - PROJECT_ROOT=src
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "3001"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   llm-server:
     image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/mcp/llm-server:latest
@@ -32,6 +52,11 @@ services:
       - MODEL=claude-3-7-sonnet-latest
       - MAX_TOKENS=1000
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "8000"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   orchestrator:
     image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/mcp/sre-orchestrator:latest

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,6 +7,11 @@ services:
       - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}
       - SLACK_TEAM_ID=${SLACK_TEAM_ID}
       - TRANSPORT=SSE
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "3001"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   kubernetes:
     build:
@@ -19,6 +24,11 @@ services:
       - TRANSPORT=SSE
       - AWS_REGION=${AWS_REGION}
       - TARGET_EKS_CLUSTER_NAME=${TARGET_EKS_CLUSTER_NAME}
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "3001"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
   github:
     build:
       context: sre_agent
@@ -26,6 +36,11 @@ services:
     environment:
       - GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN}
       - TRANSPORT=SSE
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "3001"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   prompt_server:
     build:
@@ -35,6 +50,11 @@ services:
       - GITHUB_ORGANISATION=fuzzylabs
       - GITHUB_REPO_NAME=microservices-demo
       - PROJECT_ROOT=src
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "3001"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   llm-server:
     build:
@@ -45,6 +65,11 @@ services:
       - MODEL=claude-3-7-sonnet-latest
       - MAX_TOKENS=1000
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "8000"] # Correct port 8000
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   orchestrator:
     build:
@@ -52,6 +77,18 @@ services:
       dockerfile: sre_agent/client/Dockerfile
     ports:
       - "8003:80"
+
+    depends_on:
+      slack:
+        condition: service_healthy
+      github:
+        condition: service_healthy
+      kubernetes:
+        condition: service_healthy
+      prompt_server:
+        condition: service_healthy
+      llm-server:
+        condition: service_healthy
 
     environment:
       - DEV_BEARER_TOKEN=${DEV_BEARER_TOKEN}

--- a/compose.yaml
+++ b/compose.yaml
@@ -66,7 +66,7 @@ services:
       - MAX_TOKENS=1000
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
     healthcheck:
-      test: ["CMD", "nc", "-z", "localhost", "8000"] # Correct port 8000
+      test: ["CMD", "nc", "-z", "localhost", "8000"]
       interval: 5s
       timeout: 3s
       retries: 5

--- a/sre_agent/client/client.py
+++ b/sre_agent/client/client.py
@@ -18,7 +18,7 @@ from utils.auth import is_request_valid  # type: ignore
 from utils.logger import logger  # type: ignore
 from utils.schemas import ClientConfig, MCPServer, ServerSession  # type: ignore
 
-load_dotenv()  # load environment variables from .env
+load_dotenv()
 
 PORT = 3001
 
@@ -252,7 +252,6 @@ async def run_diagnosis_and_post(service: str) -> None:
     """
     timeout = _get_client_config().query_timeout
     try:
-        # Create and manage client per request
         async with MCPClient() as client:
             logger.info(f"Creating MCPClient for service: {service}")
             try:
@@ -275,7 +274,6 @@ async def run_diagnosis_and_post(service: str) -> None:
                 # TODO: Post error back to Slack?
                 return
 
-            # Define the inner function *after* client is set up
             async def _run_diagnosis(mcp_client: MCPClient) -> dict[str, Any]:
                 """Inner function to run the actual diagnosis query."""
                 result = await mcp_client.process_query(

--- a/sre_agent/llm/Dockerfile
+++ b/sre_agent/llm/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3.12-slim
 # Install uv.
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
+RUN apt-get update && apt-get install -y netcat-openbsd && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY ../../pyproject.toml ../../uv.lock ./

--- a/sre_agent/servers/mcp-server-kubernetes/Dockerfile
+++ b/sre_agent/servers/mcp-server-kubernetes/Dockerfile
@@ -16,6 +16,8 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
 RUN apt-get update
 RUN apt-get install -y kubectl awscli
 
+RUN apt-get install -y kubectl awscli netcat-openbsd
+
 # Build the typescript code
 FROM base AS dependencies
 RUN npm install

--- a/sre_agent/servers/mcp-server-kubernetes/Dockerfile
+++ b/sre_agent/servers/mcp-server-kubernetes/Dockerfile
@@ -14,9 +14,7 @@ RUN chmod 644 /etc/apt/sources.list.d/kubernetes.list
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN apt-get update
-RUN apt-get install -y kubectl awscli
-
-RUN apt-get install -y kubectl awscli netcat-openbsd
+RUN apt-get update && apt-get install -y kubectl awscli netcat-openbsd
 
 # Build the typescript code
 FROM base AS dependencies

--- a/sre_agent/servers/prompt_server/Dockerfile
+++ b/sre_agent/servers/prompt_server/Dockerfile
@@ -10,6 +10,9 @@ COPY ../../../pyproject.toml ../../../uv.lock ./
 # Copy the application into the container.
 COPY sre_agent/servers/prompt_server .
 
+# Install netcat
+RUN apt-get update && apt-get install -y netcat-openbsd && rm -rf /var/lib/apt/lists/*
+
 # Install the application dependencies.
 WORKDIR /app
 RUN uv pip install --no-cache --system -r /app/pyproject.toml


### PR DESCRIPTION

_Write a short description which explains what this pull request does and, briefly, how._

### What

- Added a /health endpoint that checks the status of the agents MCP servers.

### Why

- Aid in debugging and enabling a liveness test.

### How

- Utilised FastAPI's lifespan context manager to create the MCPClient and connect to all required MCP servers on application startup, storing the client in app.state.
- Implemented the GET /health endpoint, which checks:
  - If the MCPClient initialised successfully during startup (via app.state).
  - If all expected MCP server connections are present and responsive (using list_tools() as a lightweight check).
- The endpoint returns a 200 OK with connected servers if healthy, or a 503 Unavailable with specific error details if the client failed to initialise or any connection check fails.
- Updated compose.yaml to add healthchecks to dependency services and depends_on with condition: service_healthy to the orchestrator to manage startup order.
### Extra

_If new dependencies are introduced to the project, please list them here:_

* _new dependency_

## Checklist

Please ensure you have done the following:

* [x] I have run application tests ensuring nothing has broken.
* [x] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Make sure to update label on right hand panel.

## MacOS tests

To trigger the CI to run on a macOS backed workflow, add the `macos-ci-test` label to the pull request (PR).

Our advice is to only run this workflow when testing the compatability between operating systems for a change that you've made, e.g., adding a new dependency to the virtual environment.

> Note: This can take up to 5 minutes to run. This workflow costs x10 more than a Linux-based workflow, use at discretion.
