### PR TITLE
[FA-150] Adding secrets manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,3 +251,5 @@ tmpcharts/
 
 # Ignore Helm release artifacts
 .release-name/
+
+*values-secrets.yaml

--- a/charts/sre-agent/charts/llm-server/templates/deployment.tpl
+++ b/charts/sre-agent/charts/llm-server/templates/deployment.tpl
@@ -25,7 +25,7 @@ spec:
             - name: ANTHROPIC_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.global.secretKeyRef }}
+                  name: "{{ .Release.Name }}-secret"
                   key: ANTHROPIC_API_KEY
             - name: PROVIDER
               value: {{ .Values.deployment.provider }}

--- a/charts/sre-agent/charts/llm-server/templates/secret.tpl
+++ b/charts/sre-agent/charts/llm-server/templates/secret.tpl
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-secret"
+type: Opaque
+stringData:
+  ANTHROPIC_API_KEY: {{ .Values.secret.anthropic_api_key | quote }}

--- a/charts/sre-agent/charts/llm-server/templates/secret.tpl
+++ b/charts/sre-agent/charts/llm-server/templates/secret.tpl
@@ -4,4 +4,4 @@ metadata:
   name: "{{ .Release.Name }}-secret"
 type: Opaque
 stringData:
-  ANTHROPIC_API_KEY: {{ .Values.secret.anthropic_api_key | quote }}
+  ANTHROPIC_API_KEY: {{ .Values.global.anthropic_api_key | b64enc | quote }}

--- a/charts/sre-agent/charts/mcp-github/templates/deployment.tpl
+++ b/charts/sre-agent/charts/mcp-github/templates/deployment.tpl
@@ -25,5 +25,5 @@ spec:
             - name: GITHUB_PERSONAL_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.global.secretKeyRef }}
+                  name: "{{ .Release.Name }}-secret"
                   key: GITHUB_PERSONAL_ACCESS_TOKEN

--- a/charts/sre-agent/charts/mcp-github/templates/secret.tpl
+++ b/charts/sre-agent/charts/mcp-github/templates/secret.tpl
@@ -4,4 +4,4 @@ metadata:
   name: "{{ .Release.Name }}-secret"
 type: Opaque
 stringData:
-  GITHUB_PERSONAL_ACCESS_TOKEN: {{ .Values.secret.github_access_token | b64enc | quote }}
+  GITHUB_PERSONAL_ACCESS_TOKEN: {{ .Values.global.github_access_token | b64enc | quote }}

--- a/charts/sre-agent/charts/mcp-github/templates/secret.tpl
+++ b/charts/sre-agent/charts/mcp-github/templates/secret.tpl
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-secret"
+type: Opaque
+stringData:
+  GITHUB_PERSONAL_ACCESS_TOKEN: {{ .Values.secret.github_access_token | b64enc | quote }}

--- a/charts/sre-agent/charts/mcp-slack/templates/deployment.tpl
+++ b/charts/sre-agent/charts/mcp-slack/templates/deployment.tpl
@@ -25,10 +25,10 @@ spec:
             - name: SLACK_BOT_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.global.secretKeyRef }}
+                  name: "{{ .Release.Name }}-secret"
                   key: SLACK_BOT_TOKEN
             - name: SLACK_TEAM_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.global.secretKeyRef }}
+                  name: "{{ .Release.Name }}-secret"
                   key: SLACK_TEAM_ID

--- a/charts/sre-agent/charts/mcp-slack/templates/secret.tpl
+++ b/charts/sre-agent/charts/mcp-slack/templates/secret.tpl
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-secret"
+type: Opaque
+stringData:
+    SLACK_BOT_TOKEN: {{ .Values.secret.slack_bot_token | b64enc | quote }}
+    SLACK_TEAM_ID: {{ .Values.secret.slack_team_id | b64enc | quote }}

--- a/charts/sre-agent/charts/mcp-slack/templates/secret.tpl
+++ b/charts/sre-agent/charts/mcp-slack/templates/secret.tpl
@@ -4,5 +4,5 @@ metadata:
   name: "{{ .Release.Name }}-secret"
 type: Opaque
 stringData:
-    SLACK_BOT_TOKEN: {{ .Values.secret.slack_bot_token | b64enc | quote }}
-    SLACK_TEAM_ID: {{ .Values.secret.slack_team_id | b64enc | quote }}
+    SLACK_BOT_TOKEN: {{ .Values.global.slack_bot_token | b64enc | quote }}
+    SLACK_TEAM_ID: {{ .Values.global.slack_team_id | b64enc | quote }}

--- a/charts/sre-agent/charts/orchestrator/templates/deployment.tpl
+++ b/charts/sre-agent/charts/orchestrator/templates/deployment.tpl
@@ -25,7 +25,7 @@ spec:
             - name: CHANNEL_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.global.secretKeyRef }}
+                  name: "{{ .Release.Name }}-secret"
                   key: CHANNEL_ID
             - name: TOOLS
               value: '["list_pods", "get_logs", "get_file_contents", "slack_post_message"]'
@@ -34,10 +34,10 @@ spec:
             - name: DEV_BEARER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.global.secretKeyRef }}
+                  name: "{{ .Release.Name }}-secret"
                   key: DEV_BEARER_TOKEN
             - name: SLACK_SIGNING_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.global.secretKeyRef }}
+                  name: "{{ .Release.Name }}-secret"
                   key: SLACK_SIGNING_SECRET

--- a/charts/sre-agent/charts/orchestrator/templates/secret.tpl
+++ b/charts/sre-agent/charts/orchestrator/templates/secret.tpl
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-secret"
+type: Opaque
+stringData:
+  CHANNEL_ID: {{ .Values.secret.channel_id | quote }}
+  DEV_BEARER_TOKEN: {{ .Values.secret.dev_bearer_token | quote }}
+  SLACK_SIGNING_SECRET: {{ .Values.slack_signing_secret | quote }}

--- a/charts/sre-agent/charts/orchestrator/templates/secret.tpl
+++ b/charts/sre-agent/charts/orchestrator/templates/secret.tpl
@@ -4,6 +4,6 @@ metadata:
   name: "{{ .Release.Name }}-secret"
 type: Opaque
 stringData:
-  CHANNEL_ID: {{ .Values.secret.channel_id | quote }}
-  DEV_BEARER_TOKEN: {{ .Values.secret.dev_bearer_token | quote }}
-  SLACK_SIGNING_SECRET: {{ .Values.slack_signing_secret | quote }}
+  CHANNEL_ID: {{ .Values.global.channel_id | b64enc | quote }}
+  DEV_BEARER_TOKEN: {{ .Values.global.dev_bearer_token | b64enc | quote }}
+  SLACK_SIGNING_SECRET: {{ .Values.global.slack_signing_secret | b64enc | quote }}

--- a/charts/sre-agent/values-secrets.yaml.example
+++ b/charts/sre-agent/values-secrets.yaml.example
@@ -1,0 +1,8 @@
+global:
+  anthropic_api_key: xxxxxxx
+  github_access_token: xxxxxxx
+  slack_bot_token: xxxxxxx
+  slack_team_id: xxxxxxx
+  slack_signing_secret: xxxxxxx
+  dev_bearer_token: xxxxxxx
+  channel_id: xxxxxxx

--- a/docs/kubernetes-deployment.md
+++ b/docs/kubernetes-deployment.md
@@ -56,6 +56,9 @@ helm install sre-agent charts/sre-agent -f charts/sre-agent/values-secrets.yaml
 ```
 
 > [!NOTE]
+> You will need to add your own `values-secrets.yaml` file, as a template is provided: [`values-secrets.yaml.example`](../charts/sre-agent/values-secrets.yaml.example)
+
+> [!NOTE]
 > You can perform a "dry-run" of the Helm chart to check for any errors before deploying with the following command:
 > ```
 > helm install sre-agent charts/sre-agent -f charts/sre-agent/values-secrets.yaml --dry-run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ max-complexity = 10
 
 # typos configuration
 [tool.typos.files]
-extend-exclude = [".gitignore", "LICENSE", ".*", "*servers*"]
+extend-exclude = [".gitignore", "LICENSE", ".*", "*servers*", "*values-secrets.yaml"]
 
 [tool.typos.default.extend-words]
 center = "center"


### PR DESCRIPTION
_Write a short description which explains what this pull request does and, briefly, how._

### What

Template files for Kubernetes secrets for each service.

### Why

Previously we had to create secrets using `kubectl`, this required a namespace ahead of doing this. With these templates we just need to run a single command to deploy.

### How

Added template files

### Extra

_If new dependencies are introduced to the project, please list them here:_

* _new dependency_

## Checklist

Please ensure you have done the following:

* [ ] I have run application tests ensuring nothing has broken.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Make sure to update label on right hand panel.

## MacOS tests

To trigger the CI to run on a macOS backed workflow, add the `macos-ci-test` label to the pull request (PR).

Our advice is to only run this workflow when testing the compatability between operating systems for a change that you've made, e.g., adding a new dependency to the virtual environment.

> Note: This can take up to 5 minutes to run. This workflow costs x10 more than a Linux-based workflow, use at discretion.
