### PR TITLE
Add bare-metal Kubernetes support and enhance README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,21 @@ npm run build && npm run watch
 
 </details>
 
+### Bare-metal/local kubeconfig
+
+If your cluster is remote, import its kubeconfig path into `.env` so the Kubernetes MCP server can use it directly:
+
+```bash
+scripts/kubeconfig-helper.sh import /path/to/kubeconfig
+```
+
+Then run the stack using the bare‑metal compose, pointing to your kubeconfig directly with `KUBECONFIG_PATH`:
+
+```bash
+export KUBECONFIG_PATH=/absolute/path/to/your/kubeconfig
+docker compose -f compose.baremetal.yaml up --build
+```
+
 ## 📚 Documentation
 
 Find all the docs you need in the [docs](docs) folder:

--- a/compose.baremetal.yaml
+++ b/compose.baremetal.yaml
@@ -1,0 +1,126 @@
+services:
+  slack:
+    build:
+      context: sre_agent
+      dockerfile: servers/slack/Dockerfile
+    env_file: .env
+    environment:
+      - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}
+      - SLACK_TEAM_ID=${SLACK_TEAM_ID}
+      - TRANSPORT=SSE
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "3001"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  kubernetes:
+    build:
+      context: sre_agent/servers/mcp-server-kubernetes
+      dockerfile: Dockerfile
+    env_file: .env
+    volumes:
+      - ${KUBECONFIG_PATH}:/home/appuser/.kube/config:ro
+    environment:
+      - TRANSPORT=SSE
+      - KUBECONFIG=/home/appuser/.kube/config
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "3001"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  github:
+    build:
+      context: sre_agent
+      dockerfile: servers/github/Dockerfile
+    env_file: .env
+    environment:
+      - GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN}
+      - TRANSPORT=SSE
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "3001"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  prompt-server:
+    build:
+      context: .
+      dockerfile: sre_agent/servers/prompt_server/Dockerfile
+    env_file: .env
+    environment:
+      - GITHUB_ORGANISATION=${GITHUB_ORGANISATION}
+      - GITHUB_REPO_NAME=${GITHUB_REPO_NAME}
+      - PROJECT_ROOT=${PROJECT_ROOT}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3001/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  llm-server:
+    build:
+      context: .
+      dockerfile: sre_agent/llm/Dockerfile
+    env_file: .env
+    environment:
+      - PROVIDER=${PROVIDER}
+      - MODEL=${MODEL}
+      - MAX_TOKENS=1000
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - GEMINI_API_KEY=${GEMINI_API_KEY}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  llama-firewall:
+    build:
+      context: .
+      dockerfile: sre_agent/firewall/Dockerfile
+    env_file: .env
+    volumes:
+      - source: ~/.cache/huggingface
+        target: /root/.cache/huggingface
+        type: bind
+        bind:
+          create_host_path: true
+    environment:
+      - HF_TOKEN=${HF_TOKEN}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  orchestrator:
+    build:
+      context: .
+      dockerfile: sre_agent/client/Dockerfile
+    env_file: .env
+    ports:
+      - "8003:80"
+
+    depends_on:
+      llama-firewall:
+        condition: service_healthy
+      slack:
+        condition: service_healthy
+      github:
+        condition: service_healthy
+      kubernetes:
+        condition: service_healthy
+      prompt-server:
+        condition: service_healthy
+      llm-server:
+        condition: service_healthy
+
+    environment:
+      - DEV_BEARER_TOKEN=${DEV_BEARER_TOKEN}
+      - QUERY_TIMEOUT=300
+      - SLACK_SIGNING_SECRET=${SLACK_SIGNING_SECRET}
+      - TOOLS=${TOOLS}
+      - SLACK_CHANNEL_ID=${SLACK_CHANNEL_ID}
+      - SERVICES=${SERVICES}

--- a/scripts/kubeconfig-helper.sh
+++ b/scripts/kubeconfig-helper.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Minimal helper to record a kubeconfig path for use by the Kubernetes MCP
+# server (remote or local clusters). It writes KUBECONFIG_PATH into .env.
+
+usage() {
+  cat <<EOF
+Usage: $0 [command]
+
+Commands:
+  import /path/to/config  Store absolute kubeconfig path into .env as KUBECONFIG_PATH
+  show                    Print the stored path from .env (if any)
+  print                   Print contexts using the stored kubeconfig path
+
+Examples:
+  $0 import /tmp/kubeconfig
+EOF
+}
+
+env_file() { echo "${ENV_FILE:-.env}"; }
+
+write_kubeconfig_path() {
+  local abs="$1"
+  local f
+  f="$(env_file)"
+  touch "$f"
+  local tmp
+  tmp="$(mktemp)"
+  awk -v val="$abs" 'BEGIN{done=0} {if($0 ~ /^KUBECONFIG_PATH=/){print "KUBECONFIG_PATH=" val; done=1} else print} END{if(!done) print "KUBECONFIG_PATH=" val}' "$f" > "$tmp"
+  mv "$tmp" "$f"
+  echo "Saved KUBECONFIG_PATH=$abs into $f"
+}
+
+case "${1:-}" in
+  import)
+    shift || true
+    [[ -n "${1:-}" && -f "$1" ]] || { echo "Provide a valid kubeconfig path" >&2; exit 1; }
+    abs_path="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+    write_kubeconfig_path "$abs_path"
+    ;;
+  show)
+    if grep -q '^KUBECONFIG_PATH=' "$(env_file)" 2>/dev/null; then
+      grep '^KUBECONFIG_PATH=' "$(env_file)"
+    else
+      echo "KUBECONFIG_PATH not set in $(env_file)"
+    fi
+    ;;
+  print)
+    if grep -q '^KUBECONFIG_PATH=' "$(env_file)" 2>/dev/null; then
+      path="$(grep '^KUBECONFIG_PATH=' "$(env_file)" | cut -d'=' -f2-)"
+      kubectl --kubeconfig "$path" config get-contexts
+    else
+      echo "KUBECONFIG_PATH not set in $(env_file). Use: $0 import /path/to/kubeconfig" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    usage
+    ;;
+esac
+

--- a/setup_credentials.py
+++ b/setup_credentials.py
@@ -82,6 +82,10 @@ def get_credential_config(platform: str) -> dict[str, dict[str, Any]]:
             "prompt": "Enter your Github project root directory: ",
             "mask_value": False,
         },
+        "KUBECONFIG_PATH": {
+            "prompt": "Enter absolute path to your kubeconfig (or leave blank to keep)",
+            "mask_value": False,
+        },
         "PROVIDER": {"prompt": "Enter your LLM provider name: ", "mask_value": False},
         "MODEL": {"prompt": "Enter your LLM model name: ", "mask_value": False},
         "GEMINI_API_KEY": {"prompt": "Enter your Gemini API Key: ", "mask_value": True},

--- a/sre_agent/servers/mcp-server-kubernetes/startup.sh
+++ b/sre_agent/servers/mcp-server-kubernetes/startup.sh
@@ -7,7 +7,11 @@ function log_error_and_exit {
   exit 1
 }
 
-if [[ -v AWS_REGION ]]; then
+if [[ -n "${KUBECONFIG:-}" && -f "$KUBECONFIG" ]]; then
+  echo "🔑 Using provided kubeconfig at: $KUBECONFIG"
+elif [[ -f "$HOME/.kube/config" ]]; then
+  echo "🔑 Using default kubeconfig at: $HOME/.kube/config"
+elif [[ -v AWS_REGION ]]; then
   echo "🔧 Updating kubeconfig for EKS cluster..."
   if ! output=$(aws eks update-kubeconfig --region $AWS_REGION --name $TARGET_EKS_CLUSTER_NAME 2>&1); then
     log_error_and_exit "$output"
@@ -18,7 +22,7 @@ elif [[ -v CLOUDSDK_COMPUTE_REGION ]]; then
     log_error_and_exit "$output"
   fi
 else
-  echo "❌ No supported environment variables not found"
+  echo "❌ No kubeconfig provided and no supported cloud env variables found"
   exit 1
 fi
 


### PR DESCRIPTION
- Introduced a new `compose.baremetal.yaml` file for deploying services with a local kubeconfig.
- Added a `kubeconfig-helper.sh` script to manage kubeconfig paths.
- Updated `setup_credentials.py` to prompt for kubeconfig path.
- Enhanced the README with instructions for using the bare-metal compose setup and kubeconfig management.

This update improves deployment flexibility for users with local Kubernetes clusters.

### What
- Add first-class bare-metal support:
  - New `compose.baremetal.yaml` mounts a kubeconfig file via `KUBECONFIG_PATH` and sets `KUBECONFIG` in the Kubernetes MCP container.
  - New `scripts/kubeconfig-helper.sh import /path/to/kubeconfig` writes `KUBECONFIG_PATH` to `.env` (no merging/rewriting kubeconfig files).
- Make Kubernetes server startup kubeconfig-aware:
  - Prefer `KUBECONFIG` if present; else use `$HOME/.kube/config`; else fall back to EKS/GKE helpers; fail fast when none is available.
- Make orchestrator auth optional for local/dev:
  - `ORCHESTRATOR_DISABLE_AUTH=true` bypasses bearer/Slack signature checks (prod defaults unchanged).
- Stabilize env parsing and setup:
  - `adds `KUBECONFIG_PATH`.
- LLM server reliability:
  - Lazy provider instantiation so non-selected providers don’t require their API keys (e.g., no `GEMINI_API_KEY` needed when `PROVIDER=anthropic`).
- Firewall gated model access:
  - Uses `HF_TOKEN`/`HUGGING_FACE_HUB_TOKEN` to log in to Hugging Face for `meta-llama/Llama-Prompt-Guard-2-86M`.

### Why
- Enable quick local/bare‑metal validation without cloud creds or kubeconfig mutation.
- Reduce onboarding friction (fewer mandatory envs, safer `.env` handling).
- Avoid spurious provider key errors when experimenting with different LLMs.
- Ensure the firewall can access gated models in a standard, documented way.

### How
- Compose:
  - `compose.baremetal.yaml` with `env_file: .env`, volume `- ${KUBECONFIG_PATH}:/home/appuser/.kube/config:ro`, and `KUBECONFIG=/home/appuser/.kube/config`.
- Kubernetes server:
  - `startup.sh` checks `KUBECONFIG` → `$HOME/.kube/config` → cloud-specific update; logs clearly and exits when none available.
- LLM:
  - Factory pattern to instantiate only the selected provider’s client.
- Firewall:
  - Login with `HF_TOKEN` if provided, then load the model/tokenizer.

### Extra
- Backward compatible:
  - Cloud flows unchanged; bare‑metal is opt‑in.
  - Auth remains enabled by default; disabling requires explicit env.
- Docs updated:
  - README: bare‑metal flow, kubeconfig helper, `KUBECONFIG_PATH` usage, optional auth notes.
- Test notes:
  - Health: `curl http://localhost:8003/health` → OK.
  - Diagnose: `curl -X POST http://localhost:8003/diagnose -H "Authorization: Bearer $DEV_BEARER_TOKEN" -d "text=<service>"`.
- Upstream project reference: see project overview and dev workflow in [fuzzylabs/sre-agent](https://github.com/fuzzylabs/sre-agent).


## Checklist

Please ensure you have done the following:

* [ x ] I have run application tests ensuring nothing has broken.
* [ x ] I have updated the documentation if required.
* [ x ] I have added tests which cover my changes.


