### PR TITLE
Eval: Add evaluation experiment for diagnoses correctness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 [project.scripts]
 sre-agent = "sre_agent.cli.main:main"
 sre-agent-run-tool-call-eval = "sre_agent.eval.tool_call.run:main"
+sre-agent-run-diagnosis-quality-eval = "sre_agent.eval.diagnosis_quality.run:main"
 
 [dependency-groups]
 dev = [

--- a/src/sre_agent/core/agent.py
+++ b/src/sre_agent/core/agent.py
@@ -12,18 +12,15 @@ from sre_agent.core.tools import (
 )
 
 
-def create_sre_agent(config: AgentSettings | None = None) -> Agent[None, ErrorDiagnosis]:
+def create_sre_agent(config: AgentSettings) -> Agent[None, ErrorDiagnosis]:
     """Create the SRE Agent with all toolsets configured.
 
     Args:
-        config: Optional AgentSettings. If not provided, loads from environment.
+        config: AgentSettings.
 
     Returns:
         Configured pydantic-ai Agent with structured output.
     """
-    if config is None:
-        config = get_settings()
-
     toolsets = [
         create_cloudwatch_toolset(config),
         create_github_mcp_toolset(config),

--- a/src/sre_agent/eval/README.md
+++ b/src/sre_agent/eval/README.md
@@ -13,13 +13,17 @@ Evaluations are implemented with [Opik](https://github.com/comet-ml/opik).
 ## Structure
 
 - `common`: shared helpers used across suites.
+- `diagnosis_quality`: evaluates diagnosis correctness and fix quality.
 - `tool_call`: evaluates tool selection and tool call order.
 
-## Current suite
+## Current suites
 
-The active suite is `tool_call`.
+The available suites are:
 
-It validates:
+- `tool_call`
+- `diagnosis_quality`
+
+`tool_call` validates:
 
 - required tool usage
 - expected tool order
@@ -30,6 +34,20 @@ It uses:
 - real GitHub MCP calls
 - mocked Slack and CloudWatch calls
 - Opik tool spans (`task_span`) for scoring
+
+
+`diagnosis_quality` validates:
+
+- root cause correctness
+- fix quality and actionability
+- affected services match
+
+It uses:
+
+- real GitHub MCP calls
+- mocked Slack and CloudWatch calls
+- output-field scoring metrics
+
 
 ## Run
 
@@ -53,3 +71,4 @@ When the server is running, open [http://localhost:5173/](http://localhost:5173/
 For suite-specific details, see:
 
 - `src/sre_agent/eval/tool_call/README.md`
+- `src/sre_agent/eval/diagnosis_quality/README.md`

--- a/src/sre_agent/eval/diagnosis_quality/README.md
+++ b/src/sre_agent/eval/diagnosis_quality/README.md
@@ -1,0 +1,69 @@
+# Diagnosis Quality Evaluation
+
+This suite checks whether the agent produces a correct diagnosis.
+
+## What it evaluates
+
+The metrics are:
+
+- `root_cause_correctness`: LLM-judge check that predicted and expected root causes align.
+- `suggested_fixes_quality`: LLM-judge check that suggested fixes are correct and actionable.
+- `affected_services_match`: deterministic overlap score between predicted and expected services.
+
+## Execution model
+
+The run is hybrid:
+
+- GitHub MCP calls are real.
+- Slack and CloudWatch tools are mocked.
+- Agent output fields are scored, not tool-call order.
+
+## Dataset shape
+
+Test cases are loaded from:
+
+- `src/sre_agent/eval/diagnosis_quality/dataset/test_cases`
+
+Each case follows `DiagnosisQualityEvalCase` in:
+
+- `src/sre_agent/eval/diagnosis_quality/dataset/schema.py`
+
+Key fields:
+
+- `case_id`
+- `service_name`
+- `github_owner`, `github_repo`, `github_ref`
+- `mock_cloudwatch_entries`
+- `expected_root_cause`
+- `expected_fix_suggestion_mentions`
+- `expected_affected_services`
+
+## Run
+
+Required environment:
+
+- `ANTHROPIC_API_KEY`
+- `GITHUB_PERSONAL_ACCESS_TOKEN`
+
+If you are running Opik locally, start the Opik platform first:
+
+```bash
+# Clone the Opik repository
+git clone https://github.com/comet-ml/opik.git
+
+# Navigate to the repository
+cd opik
+
+# Start the Opik platform
+./opik.sh
+```
+
+See [comet-ml/opik](https://github.com/comet-ml/opik) for details.
+
+When the server is running, open [http://localhost:5173/](http://localhost:5173/) to view datasets and experiments.
+
+Run command:
+
+```bash
+uv run sre-agent-run-diagnosis-quality-eval
+```

--- a/src/sre_agent/eval/diagnosis_quality/__init__.py
+++ b/src/sre_agent/eval/diagnosis_quality/__init__.py
@@ -1,0 +1,1 @@
+"""Diagnosis quality evaluation suite."""

--- a/src/sre_agent/eval/diagnosis_quality/config.py
+++ b/src/sre_agent/eval/diagnosis_quality/config.py
@@ -1,0 +1,7 @@
+"""Configuration constants for diagnosis quality evaluation."""
+
+DEFAULT_EXPERIMENT_NAME = "sre-agent-diagnosis-quality"
+DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
+DEFAULT_JUDGE_MODEL = DEFAULT_MODEL
+DEFAULT_TIME_RANGE_MINUTES = 10  # Needed for the diagnosis prompt.
+DEFAULT_SLACK_CHANNEL_ID = "MOCK_CHANNEL_ID"  # Needed for the diagnosis prompt.

--- a/src/sre_agent/eval/diagnosis_quality/config.py
+++ b/src/sre_agent/eval/diagnosis_quality/config.py
@@ -1,6 +1,7 @@
 """Configuration constants for diagnosis quality evaluation."""
 
 DEFAULT_EXPERIMENT_NAME = "sre-agent-diagnosis-quality"
+DEFAULT_OPIK_PROJECT_NAME = "sre-agent-eval"
 DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
 DEFAULT_JUDGE_MODEL = DEFAULT_MODEL
 DEFAULT_TIME_RANGE_MINUTES = 10  # Needed for the diagnosis prompt.

--- a/src/sre_agent/eval/diagnosis_quality/dataset/__init__.py
+++ b/src/sre_agent/eval/diagnosis_quality/dataset/__init__.py
@@ -1,0 +1,1 @@
+"""Dataset helpers for diagnosis quality evaluation."""

--- a/src/sre_agent/eval/diagnosis_quality/dataset/create_and_populate.py
+++ b/src/sre_agent/eval/diagnosis_quality/dataset/create_and_populate.py
@@ -1,0 +1,44 @@
+"""Dataset loading helpers for diagnosis quality evaluation."""
+
+from pathlib import Path
+from typing import Any
+
+from opik import Opik
+
+from sre_agent.eval.common.case_loader import load_json_case_models
+from sre_agent.eval.diagnosis_quality.dataset.schema import DiagnosisQualityEvalCase
+
+DEFAULT_DATASET_NAME = "sre-agent-diagnosis-quality"
+
+
+def build_from_cases_files() -> list[DiagnosisQualityEvalCase]:
+    """Load and validate local diagnosis quality cases.
+
+    Returns:
+        A list of DiagnosisQualityEvalCase instances.
+    """
+    return load_json_case_models(
+        Path(__file__).parent / "test_cases",
+        DiagnosisQualityEvalCase,
+    )
+
+
+def create_and_populate_dataset(
+    client: Opik,
+    dataset_name: str = DEFAULT_DATASET_NAME,
+) -> tuple[Any, int]:
+    """Create or replace dataset rows from local case files.
+
+    Args:
+        client: The Opik client.
+        dataset_name: The name of the dataset to create or replace.
+
+    Returns:
+        A tuple of (dataset, inserted_case_count).
+    """
+    dataset = client.get_or_create_dataset(name=dataset_name)
+    cases = build_from_cases_files()
+
+    dataset.clear()
+    dataset.insert([case.model_dump(mode="json") for case in cases])
+    return dataset, len(cases)

--- a/src/sre_agent/eval/diagnosis_quality/dataset/schema.py
+++ b/src/sre_agent/eval/diagnosis_quality/dataset/schema.py
@@ -1,0 +1,30 @@
+"""Pydantic evaluation case schema for diagnosis quality evaluation."""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class MockCloudWatchEntry(BaseModel):
+    """One mocked CloudWatch log entry."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    message: list[
+        str
+    ]  # This is a list of strings because the log message can be multiline for readability.
+
+
+class DiagnosisQualityEvalCase(BaseModel):
+    """One diagnosis quality evaluation case."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    case_id: str
+    log_group: str
+    service_name: str
+    github_owner: str
+    github_repo: str
+    github_ref: str
+    mock_cloudwatch_entries: list[MockCloudWatchEntry]
+    expected_root_cause: str
+    expected_fix_suggestion_mentions: list[str]
+    expected_affected_services: list[str]

--- a/src/sre_agent/eval/diagnosis_quality/dataset/test_cases/cartservice_test_case_01.json
+++ b/src/sre_agent/eval/diagnosis_quality/dataset/test_cases/cartservice_test_case_01.json
@@ -1,0 +1,28 @@
+{
+  "case_id": "diagnosis_quality_cartservice_test_case_01",
+  "log_group": "mock_log_group",
+  "service_name": "cartservice",
+  "github_owner": "fuzzylabs",
+  "github_repo": "sre-agent-eval",
+  "github_ref": "main",
+  "mock_cloudwatch_entries": [
+    {
+      "message": [
+        "checkout request currency=JPY",
+        "Unhandled exception. System.Collections.Generic.KeyNotFoundException: The given key 'JPY' was not present in the dictionary.",
+        "   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)",
+        "   at CartService.TestCase01.CartCalculator.CalculateTotal(CheckoutRequest request) in /cartservice/test_case_01/Program.cs:line 33",
+        "   at CartService.TestCase01.Program.Main() in cartservice/test_case_01/Program.cs:line 53"
+      ]
+    }
+  ],
+  "expected_root_cause": "The CartCalculator.CalculateTotal() method attempts to look up the requested currency in the ConversionRates dictionary at line 33.\n The dictionary only contains USD and EUR. When a checkout request with currency 'JPY' is processed, a KeyNotFoundException is thrown because JPY does not exist in the dictionary.",
+  "expected_fix_suggestion_mentions": [
+    "Handle missing currency keys safely",
+    "Add or validate JPY support in cart pricing/conversion logic",
+    "Prevent KeyNotFoundException in total calculation path"
+  ],
+  "expected_affected_services": [
+    "cartservice"
+  ]
+}

--- a/src/sre_agent/eval/diagnosis_quality/dataset/test_cases/cartservice_test_case_02.json
+++ b/src/sre_agent/eval/diagnosis_quality/dataset/test_cases/cartservice_test_case_02.json
@@ -1,0 +1,27 @@
+{
+  "case_id": "diagnosis_quality_cartservice_test_case_02",
+  "log_group": "mock_log_group",
+  "service_name": "cartservice",
+  "github_owner": "fuzzylabs",
+  "github_repo": "sre-agent-eval",
+  "github_ref": "main",
+  "mock_cloudwatch_entries": [
+    {
+      "message": [
+        "checkout request currency=JPY",
+        "Unhandled exception. System.DivideByZeroException: Attempted to divide by zero.",
+        "   at System.Decimal.DecCalc.VarDecDiv(DecCalc& d1, DecCalc& d2)",
+        "   at System.Decimal.op_Division(Decimal d1, Decimal d2)",
+        "   at CartService.TestCase02.CartCalculator.CalculateUsdTotal(CheckoutRequest request) in /cartservice/test_case_02/Program.cs:line 37",
+        "   at CartService.TestCase02.Program.Main() in /cartservice/test_case_02/Program.cs:line 56"
+      ]
+    }
+  ],
+  "expected_root_cause": "In `cartservice/test_case_02/Program.cs` at line 37, the code attempts to divide by zero when converting JPY to USD. The conversion rate for JPY is incorrectly set to `0.00m` in the `ConversionRatesToUsd` dictionary (line 22).",
+  "expected_fix_suggestion_mentions": [
+    "Update the JPY conversion rate to a valid value."
+  ],
+  "expected_affected_services": [
+    "cartservice"
+  ]
+}

--- a/src/sre_agent/eval/diagnosis_quality/dataset/test_cases/currencyservice_test_case_01.json
+++ b/src/sre_agent/eval/diagnosis_quality/dataset/test_cases/currencyservice_test_case_01.json
@@ -1,0 +1,30 @@
+{
+  "case_id": "diagnosis_quality_currencyservice_test_case_01",
+  "log_group": "mock_log_group",
+  "service_name": "currencyservice",
+  "github_owner": "fuzzylabs",
+  "github_repo": "sre-agent-eval",
+  "github_ref": "main",
+  "mock_cloudwatch_entries": [
+    {
+      "message": [
+        "2026/02/19 18:26:03 conversion request: {From:{Units:100 Nanos:500000000 CurrencyCode:USD} ToCode:JPY}",
+        "panic: interface conversion: interface {} is string, not float64",
+        "",
+        "goroutine 1 [running]:",
+        "main.convert({{0x64, 0x1dcd6500, {0x1047c2e67, 0x3}}, {0x1047c2e6d, 0x3}})",
+        "\t/currencyservice/test_case_01/main.go:48 +0xfc",
+        "main.main()",
+        "\t/currencyservice/test_case_01/main.go:66 +0xc8",
+        "exit status 2"
+      ]
+    }
+  ],
+  "expected_root_cause": "The panic occurs at /currencyservice/test_case_01/main.go:48 in the convert() function.\nThe code attempts to type assert the conversion rate for 'JPY' as float64. However, in the conversionRates map (line 18 to 23), JPY is incorrectly defined as a string '160.12' instead of a numeric value.",
+  "expected_fix_suggestion_mentions": [
+    "Change the JPY conversion rate from a string to a float64"
+  ],
+  "expected_affected_services": [
+    "currencyservice"
+  ]
+}

--- a/src/sre_agent/eval/diagnosis_quality/experiment.py
+++ b/src/sre_agent/eval/diagnosis_quality/experiment.py
@@ -15,6 +15,7 @@ from sre_agent.eval.diagnosis_quality.config import (
     DEFAULT_EXPERIMENT_NAME,
     DEFAULT_JUDGE_MODEL,
     DEFAULT_MODEL,
+    DEFAULT_OPIK_PROJECT_NAME,
 )
 from sre_agent.eval.diagnosis_quality.dataset.create_and_populate import (
     DEFAULT_DATASET_NAME,
@@ -55,8 +56,9 @@ def run_experiment(dataset_name: str = DEFAULT_DATASET_NAME) -> EvaluationResult
     Returns:
         The evaluation result.
     """
+    opik.config.update_session_config("project_name", DEFAULT_OPIK_PROJECT_NAME)
     opik.configure(use_local=True)
-    client = Opik()
+    client = Opik(project_name=DEFAULT_OPIK_PROJECT_NAME)
     dataset, _ = create_and_populate_dataset(client=client, dataset_name=dataset_name)
 
     return evaluate(
@@ -68,6 +70,7 @@ def run_experiment(dataset_name: str = DEFAULT_DATASET_NAME) -> EvaluationResult
             AffectedServicesMatch(),
         ],
         experiment_name=DEFAULT_EXPERIMENT_NAME,
+        project_name=DEFAULT_OPIK_PROJECT_NAME,
         experiment_config={
             "suite": "diagnosis_quality",
             "dataset": dataset_name,

--- a/src/sre_agent/eval/diagnosis_quality/experiment.py
+++ b/src/sre_agent/eval/diagnosis_quality/experiment.py
@@ -1,0 +1,151 @@
+"""Diagnosis quality evaluation experiment."""
+
+import asyncio
+from typing import Any
+
+import opik
+from opik import Opik
+from opik.evaluation import evaluate
+from opik.evaluation.evaluation_result import EvaluationResult
+from pydantic_ai import Agent
+
+from sre_agent.core.models import ErrorDiagnosis
+from sre_agent.core.prompts import SYSTEM_PROMPT
+from sre_agent.eval.diagnosis_quality.config import (
+    DEFAULT_EXPERIMENT_NAME,
+    DEFAULT_JUDGE_MODEL,
+    DEFAULT_MODEL,
+)
+from sre_agent.eval.diagnosis_quality.dataset.create_and_populate import (
+    DEFAULT_DATASET_NAME,
+    create_and_populate_dataset,
+)
+from sre_agent.eval.diagnosis_quality.dataset.schema import DiagnosisQualityEvalCase
+from sre_agent.eval.diagnosis_quality.github_toolset import build_github_toolset
+from sre_agent.eval.diagnosis_quality.metrics import (
+    AffectedServicesMatch,
+    RootCauseCorrectness,
+    SuggestedFixesQuality,
+)
+from sre_agent.eval.diagnosis_quality.mocks import MockToolRuntime, build_mock_toolset
+from sre_agent.eval.diagnosis_quality.prompts import render_agent_prompt
+
+
+def evaluation_task(dataset_item: dict[str, Any]) -> dict[str, Any]:
+    """Run one diagnosis-quality case through the agent loop.
+
+    Args:
+        dataset_item: The dataset item to run.
+
+    Returns:
+        The task output dictionary for Opik scoring.
+    """
+    payload = dict(dataset_item)
+    payload.pop("id", None)
+    case = DiagnosisQualityEvalCase.model_validate(payload)
+    return asyncio.run(run_case(case))
+
+
+def run_experiment(dataset_name: str = DEFAULT_DATASET_NAME) -> EvaluationResult:
+    """Run the diagnosis quality evaluation in local mode.
+
+    Args:
+        dataset_name: The name of the dataset to run.
+
+    Returns:
+        The evaluation result.
+    """
+    opik.configure(use_local=True)
+    client = Opik()
+    dataset, _ = create_and_populate_dataset(client=client, dataset_name=dataset_name)
+
+    return evaluate(
+        dataset=dataset,
+        task=evaluation_task,
+        scoring_metrics=[
+            RootCauseCorrectness(judge_model=DEFAULT_JUDGE_MODEL),
+            SuggestedFixesQuality(judge_model=DEFAULT_JUDGE_MODEL),
+            AffectedServicesMatch(),
+        ],
+        experiment_name=DEFAULT_EXPERIMENT_NAME,
+        experiment_config={
+            "suite": "diagnosis_quality",
+            "dataset": dataset_name,
+            "mode": "local",
+            "model": DEFAULT_MODEL,
+            "judge_model": DEFAULT_JUDGE_MODEL,
+            "github_mode": "real_mcp",
+            "cloudwatch_mode": "mock",
+            "slack_mode": "mock",
+        },
+    )
+
+
+async def run_case(case: DiagnosisQualityEvalCase) -> dict[str, Any]:
+    """Execute one case and return fields required for diagnosis scoring.
+
+    Args:
+        case: The case to run.
+
+    Returns:
+        Task outputs for diagnosis metrics.
+    """
+    runtime = MockToolRuntime(case)
+    github_toolset = build_github_toolset()
+    agent = Agent(
+        DEFAULT_MODEL,
+        system_prompt=SYSTEM_PROMPT,
+        output_type=ErrorDiagnosis,
+        toolsets=[build_mock_toolset(runtime), github_toolset],
+    )
+
+    result = await agent.run(render_agent_prompt(case))
+    return _to_task_output(result.output)
+
+
+def _to_task_output(diagnosis: ErrorDiagnosis) -> dict[str, Any]:
+    """Convert structured diagnosis to metric-friendly task output.
+
+    Args:
+        diagnosis: The diagnosis output from the agent.
+
+    Returns:
+        Task output dictionary for scoring metrics.
+    """
+    suggested_fixes_text = _flatten_suggested_fixes(diagnosis)
+    diagnosis_text = (
+        f"Summary: {diagnosis.summary}\n"
+        f"Root Cause: {diagnosis.root_cause}\n"
+        f"Affected Services: {', '.join(diagnosis.affected_services)}\n"
+        f"Suggested Fixes:\n{suggested_fixes_text}\n"
+        f"Related Logs:\n" + "\n".join(diagnosis.related_logs)
+    )
+
+    return {
+        "summary": diagnosis.summary,
+        "root_cause": diagnosis.root_cause,
+        "affected_services": diagnosis.affected_services,
+        "related_logs": diagnosis.related_logs,
+        "suggested_fixes_text": suggested_fixes_text,
+        "diagnosis_text": diagnosis_text,
+    }
+
+
+def _flatten_suggested_fixes(diagnosis: ErrorDiagnosis) -> str:
+    """Flatten suggested fixes into one string.
+
+    Args:
+        diagnosis: The diagnosis output from the agent.
+
+    Returns:
+        Flattened suggested fixes text.
+    """
+    parts: list[str] = []
+    for index, fix in enumerate(diagnosis.suggested_fixes, start=1):
+        lines = [f"{index}. {fix.description.strip()}"]
+        if fix.file_path:
+            lines.append(f"File: {fix.file_path.strip()}")
+        if fix.code_snippet:
+            lines.append(f"Snippet: {fix.code_snippet.strip()}")
+        parts.append("\n".join(lines))
+    return "\n\n".join(parts)

--- a/src/sre_agent/eval/diagnosis_quality/github_toolset.py
+++ b/src/sre_agent/eval/diagnosis_quality/github_toolset.py
@@ -1,0 +1,59 @@
+"""GitHub MCP toolset construction for diagnosis quality evaluation."""
+
+import os
+from typing import Any
+
+import opik
+from pydantic_ai.mcp import MCPServerStreamableHTTP
+
+
+def build_github_toolset() -> MCPServerStreamableHTTP:
+    """Build a real GitHub MCP toolset.
+
+    Returns:
+        A GitHub MCP toolset.
+    """
+    token = os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN")
+
+    if not token:
+        msg = (
+            "Missing GitHub MCP configuration. "
+            "Set GITHUB_PERSONAL_ACCESS_TOKEN before running diagnosis-quality eval."
+        )
+        raise RuntimeError(msg)
+
+    # spellchecker:ignore-next-line
+    headers = {"Authorization": f"Bearer {token}"}
+
+    async def process_tool_call(
+        _ctx: Any,
+        call_tool: Any,
+        name: str,
+        args: dict[str, Any],
+    ) -> Any:
+        """Process a tool call.
+
+        Args:
+            _ctx: The context.
+            call_tool: The call tool.
+            name: The name of the tool.
+            args: The arguments of the tool.
+
+        Returns:
+            The result of the tool call.
+        """
+        raw_args = args if isinstance(args, dict) else {}
+        with opik.start_as_current_span(
+            name=name,
+            type="tool",
+            input=raw_args,
+            metadata={"provider": "github_mcp", "mocked": False},
+        ):
+            return await call_tool(name, raw_args)
+
+    return MCPServerStreamableHTTP(
+        "https://api.githubcopilot.com/mcp/",
+        timeout=60,
+        headers=headers,
+        process_tool_call=process_tool_call,
+    )

--- a/src/sre_agent/eval/diagnosis_quality/metrics/__init__.py
+++ b/src/sre_agent/eval/diagnosis_quality/metrics/__init__.py
@@ -1,0 +1,17 @@
+"""Metrics for diagnosis quality evaluation."""
+
+from sre_agent.eval.diagnosis_quality.metrics.affected_services_match import (
+    AffectedServicesMatch,
+)
+from sre_agent.eval.diagnosis_quality.metrics.root_cause_correctness import (
+    RootCauseCorrectness,
+)
+from sre_agent.eval.diagnosis_quality.metrics.suggested_fixes_quality import (
+    SuggestedFixesQuality,
+)
+
+__all__ = [
+    "RootCauseCorrectness",
+    "SuggestedFixesQuality",
+    "AffectedServicesMatch",
+]

--- a/src/sre_agent/eval/diagnosis_quality/metrics/affected_services_match.py
+++ b/src/sre_agent/eval/diagnosis_quality/metrics/affected_services_match.py
@@ -1,0 +1,61 @@
+"""Affected services match metric for diagnosis quality evaluation."""
+
+from typing import Any
+
+from opik.evaluation.metrics import base_metric, score_result
+
+
+class AffectedServicesMatch(base_metric.BaseMetric):
+    """Score overlap between predicted and expected affected services."""
+
+    def __init__(self, name: str = "affected_services_match") -> None:
+        """Initialise the affected services match metric.
+
+        Args:
+            name: The metric name.
+        """
+        super().__init__(name=name)
+
+    def score(
+        self,
+        affected_services: list[str],
+        expected_affected_services: list[str],
+        **ignored_kwargs: Any,
+    ) -> score_result.ScoreResult:
+        """Score affected services overlap using Jaccard similarity.
+
+        Args:
+            affected_services: Predicted affected services.
+            expected_affected_services: Expected affected services.
+            **ignored_kwargs: Ignore other keyword arguments.
+
+        Returns:
+            A score result.
+        """
+        predicted = {service.strip().lower() for service in affected_services if service.strip()}
+        expected = {
+            service.strip().lower() for service in expected_affected_services if service.strip()
+        }
+
+        union = predicted | expected
+        if not union:
+            # Both sets are empty: no services were expected and none were predicted.
+            return score_result.ScoreResult(
+                name=self.name,
+                value=1.0,
+                reason="No affected services expected and none predicted.",
+            )
+
+        # Jaccard
+        intersection = predicted & expected
+        value = len(intersection) / len(union)
+        missing = sorted(expected - predicted)
+        unexpected = sorted(predicted - expected)
+        reason = (
+            f"Overlap={len(intersection)}/{len(union)}. Missing={missing}. Unexpected={unexpected}."
+        )
+        return score_result.ScoreResult(
+            name=self.name,
+            value=value,
+            reason=reason,
+        )

--- a/src/sre_agent/eval/diagnosis_quality/metrics/root_cause_correctness.py
+++ b/src/sre_agent/eval/diagnosis_quality/metrics/root_cause_correctness.py
@@ -30,7 +30,8 @@ class RootCauseCorrectness(base_metric.BaseMetric):
             evaluation_criteria=(
                 "Compare the predicted root cause against the expected root cause. "
                 "Score high when they refer to the same underlying failure mechanism. "
-                "Penalise incorrect, unrelated, or vague diagnoses."
+                "Penalise incorrect, unrelated, or vague diagnoses. "
+                "Return an integer score from 0 to 10 only."
             ),
             model=judge_model,
             name=f"{name}_judge",

--- a/src/sre_agent/eval/diagnosis_quality/metrics/root_cause_correctness.py
+++ b/src/sre_agent/eval/diagnosis_quality/metrics/root_cause_correctness.py
@@ -21,7 +21,12 @@ class RootCauseCorrectness(base_metric.BaseMetric):
         """
         super().__init__(name=name)
         self._judge = GEval(
-            task_introduction="You are evaluating SRE root-cause diagnoses.",
+            task_introduction=(
+                "You are an SRE expert judge tasked with evaluating root-cause "
+                "statements for production incidents. You will be given both the "
+                "submitted diagnosis and the expected root cause, and your job is "
+                "to assess whether the diagnosis is accurate."
+            ),
             evaluation_criteria=(
                 "Compare the predicted root cause against the expected root cause. "
                 "Score high when they refer to the same underlying failure mechanism. "

--- a/src/sre_agent/eval/diagnosis_quality/metrics/root_cause_correctness.py
+++ b/src/sre_agent/eval/diagnosis_quality/metrics/root_cause_correctness.py
@@ -1,0 +1,73 @@
+"""Root cause correctness metric for diagnosis quality evaluation."""
+
+from typing import Any
+
+from opik.evaluation.metrics import GEval, base_metric, score_result
+
+
+class RootCauseCorrectness(base_metric.BaseMetric):
+    """Judge whether the root cause matches the expected issue."""
+
+    def __init__(
+        self,
+        judge_model: str,
+        name: str = "root_cause_correctness",
+    ) -> None:
+        """Initialise the root cause correctness metric.
+
+        Args:
+            judge_model: The model used for LLM-as-a-judge scoring.
+            name: The metric name.
+        """
+        super().__init__(name=name)
+        self._judge = GEval(
+            task_introduction="You are evaluating SRE root-cause diagnoses.",
+            evaluation_criteria=(
+                "Compare the predicted root cause against the expected root cause. "
+                "Score high when they refer to the same underlying failure mechanism. "
+                "Penalise incorrect, unrelated, or vague diagnoses."
+            ),
+            model=judge_model,
+            name=f"{name}_judge",
+            track=False,  # No need tracing
+        )
+
+    def score(
+        self,
+        root_cause: str,
+        expected_root_cause: str,
+        service_name: str,
+        **ignored_kwargs: Any,
+    ) -> score_result.ScoreResult:
+        """Score root-cause correctness.
+
+        Args:
+            root_cause: The predicted root cause.
+            expected_root_cause: The expected root cause.
+            service_name: The service under evaluation.
+            **ignored_kwargs: Ignore other keyword arguments.
+
+        Returns:
+            A score result.
+        """
+        if not root_cause.strip():
+            return score_result.ScoreResult(
+                name=self.name,
+                value=0.0,
+                reason="Missing root cause in model output.",
+            )
+
+        # https://www.comet.com/docs/opik/evaluation/metrics/g_eval
+        # Everything in one payload suggested by the docs.
+        comparison_text = (
+            f"Service: {service_name}\n"
+            f"Expected Root Cause:\n{expected_root_cause}\n\n"
+            f"Predicted Root Cause:\n{root_cause}"
+        )
+
+        judged = self._judge.score(output=comparison_text)
+        return score_result.ScoreResult(
+            name=self.name,
+            value=float(judged.value),
+            reason=judged.reason,
+        )

--- a/src/sre_agent/eval/diagnosis_quality/metrics/suggested_fixes_quality.py
+++ b/src/sre_agent/eval/diagnosis_quality/metrics/suggested_fixes_quality.py
@@ -32,7 +32,8 @@ class SuggestedFixesQuality(base_metric.BaseMetric):
             evaluation_criteria=(
                 "Score the predicted fix suggestions against expected fix suggestion mentions. "
                 "High scores require correct direction, concrete implementation guidance, "
-                "and alignment with the stated root cause."
+                "and alignment with the stated root cause. "
+                "Return an integer score from 0 to 10 only."
             ),
             model=judge_model,
             name=f"{name}_judge",
@@ -72,7 +73,14 @@ class SuggestedFixesQuality(base_metric.BaseMetric):
             f"Predicted Fix Suggestions:\n{suggested_fixes_text}"
         )
 
-        judged = self._judge.score(output=comparison_text)
+        try:
+            judged = self._judge.score(output=comparison_text)
+        except Exception as exc:
+            return score_result.ScoreResult(
+                name=self.name,
+                value=0.0,
+                reason=f"Judge failed to score suggested fixes: {exc}",
+            )
 
         return score_result.ScoreResult(
             name=self.name,

--- a/src/sre_agent/eval/diagnosis_quality/metrics/suggested_fixes_quality.py
+++ b/src/sre_agent/eval/diagnosis_quality/metrics/suggested_fixes_quality.py
@@ -1,0 +1,81 @@
+"""Suggested fixes quality metric for diagnosis quality evaluation."""
+
+from typing import Any
+
+from opik.evaluation.metrics import GEval, base_metric, score_result
+
+
+class SuggestedFixesQuality(base_metric.BaseMetric):
+    """Judge whether suggested fixes are correct and actionable."""
+
+    def __init__(
+        self,
+        judge_model: str,
+        name: str = "suggested_fixes_quality",
+    ) -> None:
+        """Initialise the fix quality metric.
+
+        Args:
+            judge_model: The model used for LLM-as-a-judge scoring.
+            name: The metric name.
+        """
+        super().__init__(name=name)
+        self._judge = GEval(
+            task_introduction=(
+                "You are an SRE expert judge tasked with evaluating remediation "
+                "suggestions for production incidents. You will be given the "
+                "predicted fix suggestions, the diagnosis context, and the expected "
+                "fix suggestion mentions. Assess whether the predicted fix "
+                "suggestions align with the expected fix suggestions and determine "
+                "whether they are correct and actionable."
+            ),
+            evaluation_criteria=(
+                "Score the predicted fix suggestions against expected fix suggestion mentions. "
+                "High scores require correct direction, concrete implementation guidance, "
+                "and alignment with the stated root cause."
+            ),
+            model=judge_model,
+            name=f"{name}_judge",
+            track=False,
+        )
+
+    def score(
+        self,
+        root_cause: str,
+        predicted_fix_suggestions_text: str,
+        expected_fix_suggestion_mentions: list[str],
+        **ignored_kwargs: Any,
+    ) -> score_result.ScoreResult:
+        """Score suggested fix quality.
+
+        Args:
+            root_cause: The predicted root cause.
+            predicted_fix_suggestions_text: The flattened predicted fix suggestions text.
+            expected_fix_suggestion_mentions: Expected mentions in fix suggestions.
+            **ignored_kwargs: Ignore other keyword arguments.
+
+        Returns:
+            A score result.
+        """
+        if not predicted_fix_suggestions_text.strip():
+            return score_result.ScoreResult(
+                name=self.name,
+                value=0.0,
+                reason="No predicted fix suggestions in model output.",
+            )
+
+        expected_text = "\n".join(f"- {item}" for item in expected_fix_suggestion_mentions)
+
+        comparison_text = (
+            f"Predicted Root Cause:\n{root_cause}\n\n"
+            f"Expected Fix Suggestions:\n{expected_text}\n\n"
+            f"Predicted Fix Suggestions:\n{predicted_fix_suggestions_text}"
+        )
+
+        judged = self._judge.score(output=comparison_text)
+
+        return score_result.ScoreResult(
+            name=self.name,
+            value=float(judged.value),
+            reason=judged.reason,
+        )

--- a/src/sre_agent/eval/diagnosis_quality/metrics/suggested_fixes_quality.py
+++ b/src/sre_agent/eval/diagnosis_quality/metrics/suggested_fixes_quality.py
@@ -42,7 +42,7 @@ class SuggestedFixesQuality(base_metric.BaseMetric):
     def score(
         self,
         root_cause: str,
-        predicted_fix_suggestions_text: str,
+        suggested_fixes_text: str,
         expected_fix_suggestion_mentions: list[str],
         **ignored_kwargs: Any,
     ) -> score_result.ScoreResult:
@@ -50,14 +50,14 @@ class SuggestedFixesQuality(base_metric.BaseMetric):
 
         Args:
             root_cause: The predicted root cause.
-            predicted_fix_suggestions_text: The flattened predicted fix suggestions text.
+            suggested_fixes_text: The flattened predicted fix suggestions text.
             expected_fix_suggestion_mentions: Expected mentions in fix suggestions.
             **ignored_kwargs: Ignore other keyword arguments.
 
         Returns:
             A score result.
         """
-        if not predicted_fix_suggestions_text.strip():
+        if not suggested_fixes_text.strip():
             return score_result.ScoreResult(
                 name=self.name,
                 value=0.0,
@@ -69,7 +69,7 @@ class SuggestedFixesQuality(base_metric.BaseMetric):
         comparison_text = (
             f"Predicted Root Cause:\n{root_cause}\n\n"
             f"Expected Fix Suggestions:\n{expected_text}\n\n"
-            f"Predicted Fix Suggestions:\n{predicted_fix_suggestions_text}"
+            f"Predicted Fix Suggestions:\n{suggested_fixes_text}"
         )
 
         judged = self._judge.score(output=comparison_text)

--- a/src/sre_agent/eval/diagnosis_quality/mocks/__init__.py
+++ b/src/sre_agent/eval/diagnosis_quality/mocks/__init__.py
@@ -1,0 +1,9 @@
+"""Mock tools for diagnosis quality evaluation."""
+
+from sre_agent.eval.diagnosis_quality.mocks.runtime import MockToolRuntime
+from sre_agent.eval.diagnosis_quality.mocks.toolset import build_mock_toolset
+
+__all__ = [
+    "MockToolRuntime",
+    "build_mock_toolset",
+]

--- a/src/sre_agent/eval/diagnosis_quality/mocks/cloudwatch.py
+++ b/src/sre_agent/eval/diagnosis_quality/mocks/cloudwatch.py
@@ -1,0 +1,50 @@
+"""Mock CloudWatch tools for diagnosis quality evaluation."""
+
+import opik
+
+from sre_agent.core.models import LogEntry, LogQueryResult
+from sre_agent.eval.diagnosis_quality.mocks.runtime import MockToolRuntime
+
+MOCK_TIMESTAMP = "2026-01-01T00:00:00+00:00"
+
+
+async def search_error_logs(
+    runtime: MockToolRuntime,
+    log_group: str,
+    service_name: str,
+    time_range_minutes: int,
+) -> LogQueryResult:
+    """Mock CloudWatch log lookup using case fixtures."""
+    with opik.start_as_current_span(
+        name="search_error_logs",
+        type="tool",
+        input={
+            "log_group": log_group,
+            "service_name": service_name,
+            "time_range_minutes": time_range_minutes,
+        },
+        metadata={"mocked": True, "provider": "cloudwatch"},
+    ):
+        entries = [
+            LogEntry(
+                timestamp=MOCK_TIMESTAMP,
+                message=message,
+                log_stream=None,
+            )
+            for message in _normalise_messages(runtime)
+        ]
+        return LogQueryResult(
+            entries=entries,
+            log_group=log_group,
+            query=f"mock: search_error_logs service={service_name}",
+        )
+
+
+def _normalise_messages(runtime: MockToolRuntime) -> list[str]:
+    """Convert multiline fixture entries into non-empty log messages."""
+    messages: list[str] = []
+    for entry in runtime.case.mock_cloudwatch_entries:
+        message = "\n".join(line.rstrip("\n") for line in entry.message).strip()
+        if message:
+            messages.append(message)
+    return messages

--- a/src/sre_agent/eval/diagnosis_quality/mocks/runtime.py
+++ b/src/sre_agent/eval/diagnosis_quality/mocks/runtime.py
@@ -1,0 +1,12 @@
+"""Runtime state for diagnosis quality mocked tools."""
+
+from dataclasses import dataclass
+
+from sre_agent.eval.diagnosis_quality.dataset.schema import DiagnosisQualityEvalCase
+
+
+@dataclass
+class MockToolRuntime:
+    """Runtime state for one eval case."""
+
+    case: DiagnosisQualityEvalCase

--- a/src/sre_agent/eval/diagnosis_quality/mocks/slack.py
+++ b/src/sre_agent/eval/diagnosis_quality/mocks/slack.py
@@ -1,0 +1,29 @@
+"""Mock Slack tools for diagnosis quality evaluation."""
+
+from typing import Any
+
+import opik
+
+MOCK_THREAD_TS = "1800000000.1000"
+
+
+async def conversations_add_message(
+    channel_id: str,
+    payload: str,
+    thread_ts: str | None,
+) -> dict[str, Any]:
+    """Mock Slack conversations_add_message."""
+    span_input: dict[str, Any] = {"channel_id": channel_id, "payload": payload}
+    if thread_ts is not None:
+        span_input["thread_ts"] = thread_ts
+
+    with opik.start_as_current_span(
+        name="conversations_add_message",
+        type="tool",
+        input=span_input,
+        metadata={"mocked": True, "provider": "slack"},
+    ):
+        if thread_ts is None:
+            return {"ok": True, "channel": channel_id, "ts": MOCK_THREAD_TS}
+
+        return {"ok": True, "channel": channel_id, "ts": thread_ts}

--- a/src/sre_agent/eval/diagnosis_quality/mocks/toolset.py
+++ b/src/sre_agent/eval/diagnosis_quality/mocks/toolset.py
@@ -1,0 +1,44 @@
+"""Mock toolset builder for diagnosis quality evaluation."""
+
+from typing import Any
+
+from pydantic_ai import FunctionToolset
+
+from sre_agent.core.models import LogQueryResult
+from sre_agent.eval.diagnosis_quality.mocks import cloudwatch as cloudwatch_mocks
+from sre_agent.eval.diagnosis_quality.mocks import slack as slack_mocks
+from sre_agent.eval.diagnosis_quality.mocks.runtime import MockToolRuntime
+
+
+def build_mock_toolset(runtime: MockToolRuntime) -> FunctionToolset:
+    """Build mocked Slack and CloudWatch toolset."""
+    toolset = FunctionToolset()
+
+    @toolset.tool
+    async def conversations_add_message(
+        channel_id: str,
+        payload: str,
+        thread_ts: str | None = None,
+    ) -> dict[str, Any]:
+        """Mock Slack message posting."""
+        return await slack_mocks.conversations_add_message(
+            channel_id,
+            payload,
+            thread_ts,
+        )
+
+    @toolset.tool
+    async def search_error_logs(
+        log_group: str,
+        service_name: str,
+        time_range_minutes: int = 10,
+    ) -> LogQueryResult:
+        """Mock CloudWatch error search."""
+        return await cloudwatch_mocks.search_error_logs(
+            runtime,
+            log_group,
+            service_name,
+            time_range_minutes,
+        )
+
+    return toolset

--- a/src/sre_agent/eval/diagnosis_quality/prompts.py
+++ b/src/sre_agent/eval/diagnosis_quality/prompts.py
@@ -1,0 +1,30 @@
+"""Prompt rendering for diagnosis quality evaluation."""
+
+from sre_agent.core.prompts import DIAGNOSIS_PROMPT_TEMPLATE
+from sre_agent.eval.diagnosis_quality.config import (
+    DEFAULT_SLACK_CHANNEL_ID,
+    DEFAULT_TIME_RANGE_MINUTES,
+)
+from sre_agent.eval.diagnosis_quality.dataset.schema import DiagnosisQualityEvalCase
+
+
+def render_agent_prompt(case: DiagnosisQualityEvalCase) -> str:
+    """Render diagnosis prompt with fixed GitHub scope context.
+
+    Args:
+        case: The case to run.
+
+    Returns:
+        The diagnosis prompt.
+    """
+    prompt = DIAGNOSIS_PROMPT_TEMPLATE.format(
+        log_group=case.log_group,
+        time_range_minutes=DEFAULT_TIME_RANGE_MINUTES,
+        service_display=case.service_name,
+        owner=case.github_owner,
+        repo=case.github_repo,
+        ref=case.github_ref,
+        channel_id=DEFAULT_SLACK_CHANNEL_ID,
+    )
+
+    return prompt

--- a/src/sre_agent/eval/diagnosis_quality/run.py
+++ b/src/sre_agent/eval/diagnosis_quality/run.py
@@ -1,0 +1,29 @@
+"""Run diagnosis quality evaluation."""
+
+from pydantic_ai.exceptions import UserError
+
+from sre_agent.eval.diagnosis_quality.config import DEFAULT_EXPERIMENT_NAME
+from sre_agent.eval.diagnosis_quality.dataset.create_and_populate import DEFAULT_DATASET_NAME
+from sre_agent.eval.diagnosis_quality.experiment import run_experiment
+
+
+def main() -> None:
+    """Run diagnosis quality evaluation with default configuration."""
+    try:
+        result = run_experiment()
+    except UserError as exc:
+        print("Model configuration error for eval run.")
+        print("Set the provider API key for the configured model before running the eval.")
+        raise SystemExit(1) from exc
+    except RuntimeError as exc:
+        print(str(exc))
+        raise SystemExit(1) from exc
+
+    test_results = getattr(result, "test_results", None) or getattr(result, "testResults", [])
+    print(f"Experiment: {DEFAULT_EXPERIMENT_NAME}")
+    print(f"Dataset: {DEFAULT_DATASET_NAME}")
+    print(f"Cases evaluated: {len(test_results)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sre_agent/eval/tool_call/config.py
+++ b/src/sre_agent/eval/tool_call/config.py
@@ -1,6 +1,7 @@
 """Configuration constants for tool call evaluation."""
 
 DEFAULT_EXPERIMENT_NAME = "sre-agent-tool-call"
+DEFAULT_OPIK_PROJECT_NAME = "sre-agent-eval"
 DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
 DEFAULT_TIME_RANGE_MINUTES = 10  # Needed for the diagnosis prompt.
 DEFAULT_SLACK_CHANNEL_ID = "MOCK_CHANNEL_ID"  # Needed for the diagnosis prompt.

--- a/src/sre_agent/eval/tool_call/experiment.py
+++ b/src/sre_agent/eval/tool_call/experiment.py
@@ -14,6 +14,7 @@ from sre_agent.core.prompts import SYSTEM_PROMPT
 from sre_agent.eval.tool_call.config import (
     DEFAULT_EXPERIMENT_NAME,
     DEFAULT_MODEL,
+    DEFAULT_OPIK_PROJECT_NAME,
 )
 from sre_agent.eval.tool_call.dataset.create_and_populate import (
     DEFAULT_DATASET_NAME,
@@ -53,8 +54,9 @@ def run_experiment(dataset_name: str = DEFAULT_DATASET_NAME) -> EvaluationResult
     Returns:
         The evaluation result.
     """
+    opik.config.update_session_config("project_name", DEFAULT_OPIK_PROJECT_NAME)
     opik.configure(use_local=True)
-    client = Opik()
+    client = Opik(project_name=DEFAULT_OPIK_PROJECT_NAME)
     dataset, _ = create_and_populate_dataset(client=client, dataset_name=dataset_name)
 
     return evaluate(
@@ -62,6 +64,7 @@ def run_experiment(dataset_name: str = DEFAULT_DATASET_NAME) -> EvaluationResult
         task=evaluation_task,
         scoring_metrics=[ExpectedToolSelectOrder(), ExpectedToolSelection()],
         experiment_name=DEFAULT_EXPERIMENT_NAME,
+        project_name=DEFAULT_OPIK_PROJECT_NAME,
         experiment_config={
             "suite": "tool_call",
             "dataset": dataset_name,

--- a/src/sre_agent/eval/tool_call/metrics/span_tools.py
+++ b/src/sre_agent/eval/tool_call/metrics/span_tools.py
@@ -12,34 +12,23 @@ def extract_tool_names(task_span: SpanModel) -> list[str]:
     Returns:
         The ordered names of the tools used in the task.
     """
-    names: list[str] = []
-    for span in _iter_spans(task_span):
-        if getattr(span, "type", None) != "tool":
-            continue
-
-        name = str(getattr(span, "name", "")).strip()
-        if name:
-            names.append(name)
-
-    return names
+    tool_names: list[str] = []
+    _collect_tool_names(task_span.spans, tool_names)
+    return tool_names
 
 
-def _iter_spans(span: SpanModel) -> list[SpanModel]:
-    """Traverse span tree in depth-first order.
+def _collect_tool_names(spans: list[SpanModel], tool_names: list[str]) -> None:
+    """Collect tool names from nested spans.
 
     Args:
-        span: The span to traverse.
-
-    Returns:
-        The ordered spans.
+        spans: The spans to inspect.
+        tool_names: The list used to store tool names.
     """
-    stack = [span]
-    ordered: list[SpanModel] = []
+    for span in spans:
+        if span.type == "tool" and span.name:
+            name = span.name.strip()
+            if name:
+                tool_names.append(name)
 
-    while stack:
-        current = stack.pop()
-        ordered.append(current)
-        children = list(getattr(current, "spans", []) or [])
-        stack.extend(reversed(children))
-
-    return ordered
+        if span.spans:
+            _collect_tool_names(span.spans, tool_names)


### PR DESCRIPTION
### What

- Implement the diagnosis quality evaluation suite
- Set Opik project to sre-agent-eval (instead of default) for both eval suites:
  - diagnosis quality
  - tool call

Implements #156 

## Checklist

Please ensure you have done the following:

* [ ] I have run application tests ensuring nothing has broken.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Make sure to update label on right hand panel.

## MacOS tests

To trigger the CI to run on a macOS backed workflow, add the `macos-ci-test` label to the pull request (PR).

Our advice is to only run this workflow when testing the compatability between operating systems for a change that you've made, e.g., adding a new dependency to the virtual environment.

> Note: This can take up to 5 minutes to run. This workflow costs x10 more than a Linux-based workflow, use at discretion.
