### PR TITLE
Release workflow & `RELEASE.md`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: pypi
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.10.9"
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        run: uv publish --trusted-publishing always

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -47,7 +47,7 @@ Ensure CI passes and get the required approvals.
 
 ### 4. Merge and tag
 
-Once the PR is approved and merged, tag the release from `main`:
+Once the PR is approved, merge it into `main` via GitHub. Then tag the merge commit locally:
 
 ```bash
 git checkout main
@@ -56,7 +56,16 @@ git tag vX.Y.Z
 git push origin vX.Y.Z
 ```
 
-### 5. Create a GitHub release
+### 5. Publish to PyPI
+
+Publishing happens automatically via GitHub Actions when a `v*` tag is pushed
+(see `.github/workflows/publish.yml`). The workflow uses
+[Trusted Publishers](https://docs.pypi.org/trusted-publishers/) so no API tokens
+need to be stored as secrets.
+
+Verify the release is live at https://pypi.org/project/sre-agent/.
+
+### 6. Create a GitHub release
 
 Create a release on GitHub from the new tag:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,87 @@
+# Release Guide
+
+This document describes the process for creating a new release of `sre-agent`.
+
+## Prerequisites
+
+- You have push access to the repository.
+- All features and fixes intended for the release have been merged into `main`.
+- CI is passing on `main`.
+
+## Steps
+
+### 1. Create a release branch
+
+Branch off `main` using the `release/` prefix:
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b release/vX.Y.Z
+```
+
+### 2. Bump the version
+
+Update the version in `pyproject.toml`:
+
+```toml
+version = "X.Y.Z"
+```
+
+Commit the version bump:
+
+```bash
+git add pyproject.toml
+git commit -m "Bump version to vX.Y.Z"
+```
+
+### 3. Open a pull request
+
+Push the release branch and open a PR against `main`:
+
+```bash
+git push -u origin release/vX.Y.Z
+```
+
+Ensure CI passes and get the required approvals.
+
+### 4. Merge and tag
+
+Once the PR is approved and merged, tag the release from `main`:
+
+```bash
+git checkout main
+git pull origin main
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+### 5. Create a GitHub release
+
+Create a release on GitHub from the new tag:
+
+```bash
+gh release create vX.Y.Z --generate-notes --title "vX.Y.Z"
+```
+
+Review and edit the auto-generated notes as needed.
+
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/):
+
+- **MAJOR** — incompatible API or behaviour changes
+- **MINOR** — new functionality, backwards-compatible
+- **PATCH** — backwards-compatible bug fixes
+
+## Hotfixes
+
+For urgent fixes against a release that is already published:
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b hotfix/vX.Y.Z
+```
+
+Follow the same process: bump version, open a PR, merge, tag, and create a GitHub release.


### PR DESCRIPTION
### What
- Add release guide and automated PyPI publishing

- Adds `RELEASE.md` documenting the end-to-end release process (branching, versioning, tagging, and GitHub releases), and a `.github/workflows/publish.yml` workflow that automatically builds and publishes the package to PyPI when a v* tag is pushed, using Trusted Publishers.