### PR TITLE
fix: validate time_range_minutes from CLI args in run.py

### DIFF
--- a/src/sre_agent/run.py
+++ b/src/sre_agent/run.py
@@ -18,12 +18,33 @@ logging.basicConfig(level=logging.INFO)
 logging.getLogger("pydantic_ai").setLevel(logging.INFO)
 
 
+def _parse_time_range_minutes(raw: str) -> int:
+    """Parse and validate a time range minutes value.
+
+    Args:
+        raw: Raw time range value from CLI args or environment.
+
+    Returns:
+        The validated time range in minutes.
+    """
+    try:
+        minutes = int(raw)
+    except ValueError as exc:
+        print("time_range_minutes must be an integer.")
+        raise SystemExit(1) from exc
+
+    if minutes <= 0:
+        print("time_range_minutes must be greater than 0.")
+        raise SystemExit(1)
+    return minutes
+
+
 def _load_request_from_args_or_env() -> tuple[str, str, int]:
     """Load diagnosis inputs from CLI args or environment."""
     if len(sys.argv) >= 3:
         log_group = sys.argv[1]
         service_name = sys.argv[2]
-        time_range_minutes = int(sys.argv[3]) if len(sys.argv) > 3 else 10
+        time_range_minutes = _parse_time_range_minutes(sys.argv[3]) if len(sys.argv) > 3 else 10
         return log_group, service_name, time_range_minutes
 
     log_group = os.getenv("LOG_GROUP", "").strip()
@@ -35,16 +56,7 @@ def _load_request_from_args_or_env() -> tuple[str, str, int]:
         )
         raise SystemExit(1)
 
-    raw_time_range = os.getenv("TIME_RANGE_MINUTES", "10").strip()
-    try:
-        time_range_minutes = int(raw_time_range)
-    except ValueError as exc:
-        print("TIME_RANGE_MINUTES must be an integer.")
-        raise SystemExit(1) from exc
-
-    if time_range_minutes <= 0:
-        print("TIME_RANGE_MINUTES must be greater than 0.")
-        raise SystemExit(1)
+    time_range_minutes = _parse_time_range_minutes(os.getenv("TIME_RANGE_MINUTES", "10").strip())
     return log_group, service_name, time_range_minutes
 
 

--- a/tests/test_run_args.py
+++ b/tests/test_run_args.py
@@ -1,0 +1,63 @@
+"""Tests for CLI and env argument parsing in sre_agent.run."""
+
+import pytest
+
+from sre_agent.run import _load_request_from_args_or_env, _parse_time_range_minutes
+
+
+def test_parse_time_range_minutes_valid() -> None:
+    """Valid integer strings are parsed."""
+    assert _parse_time_range_minutes("15") == 15
+
+
+def test_parse_time_range_minutes_non_integer_exits(capsys: pytest.CaptureFixture[str]) -> None:
+    """Non integer input exits with a friendly message rather than crashing."""
+    with pytest.raises(SystemExit) as excinfo:
+        _parse_time_range_minutes("abc")
+    assert excinfo.value.code == 1
+    assert "must be an integer" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("raw", ["0", "-5"])
+def test_parse_time_range_minutes_non_positive_exits(
+    raw: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Zero and negative values are rejected."""
+    with pytest.raises(SystemExit) as excinfo:
+        _parse_time_range_minutes(raw)
+    assert excinfo.value.code == 1
+    assert "greater than 0" in capsys.readouterr().out
+
+
+def test_cli_args_invalid_time_range_exits(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Bad CLI third argument exits cleanly instead of raising ValueError."""
+    monkeypatch.setattr("sys.argv", ["run.py", "log-group", "service", "abc"])
+    with pytest.raises(SystemExit) as excinfo:
+        _load_request_from_args_or_env()
+    assert excinfo.value.code == 1
+    assert "must be an integer" in capsys.readouterr().out
+
+
+def test_cli_args_non_positive_time_range_exits(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A zero or negative CLI third argument is rejected."""
+    monkeypatch.setattr("sys.argv", ["run.py", "log-group", "service", "0"])
+    with pytest.raises(SystemExit) as excinfo:
+        _load_request_from_args_or_env()
+    assert excinfo.value.code == 1
+    assert "greater than 0" in capsys.readouterr().out
+
+
+def test_cli_args_valid() -> None:
+    """Valid CLI args parse as expected."""
+    import sys
+
+    original = sys.argv
+    try:
+        sys.argv = ["run.py", "log-group", "service", "42"]
+        assert _load_request_from_args_or_env() == ("log-group", "service", 42)
+    finally:
+        sys.argv = original


### PR DESCRIPTION
### What

Fix inconsistent handling of `time_range_minutes` in `sre_agent/run.py` between the CLI-argument and environment-variable code paths. The CLI path now validates the value the same way the env path does.

### Why

The documented invocation in `DEVELOPMENT.md` is:

```bash
uv run python run.py /aws/containerinsights/no-loafers-for-you/application cartservice
```

…optionally with a third positional argument for minutes. In `_load_request_from_args_or_env` (`src/sre_agent/run.py:L26`), the CLI branch calls `int(sys.argv[3])` directly, while the env branch (`L38-L46`) already wraps the parse in `try/except ValueError` and rejects `<= 0`.

Two real issues follow:

1. **Unhandled crash on typo.** A non-integer third argument raises `ValueError: invalid literal for int() with base 10: 'abc'` with a full traceback instead of the friendly `"time_range_minutes must be an integer."` message the env path prints.
2. **Silent acceptance of invalid values.** `python -m sre_agent.run foo bar 0` and `... -5` are accepted on the CLI path, even though the env path rejects both. The same-shape validation in `src/sre_agent/cli/mode/remote/aws/ecs/steps.py:L402-L409` also rejects `<= 0`, so the CLI path is the outlier.

**Reproduction** (before this patch):

```console
$ python -c "import sys; sys.argv=['run.py','logs','svc','abc']; \
    from sre_agent.run import _load_request_from_args_or_env; \
    _load_request_from_args_or_env()"
ValueError: invalid literal for int() with base 10: 'abc'

$ python -c "import sys; sys.argv=['run.py','logs','svc','-5']; \
    from sre_agent.run import _load_request_from_args_or_env; \
    print(_load_request_from_args_or_env())"
('logs', 'svc', -5)   # silently accepted, feeds a negative timedelta into CloudWatch
```

### How

- Extract the parse-and-validate logic into `_parse_time_range_minutes(raw: str) -> int` and call it from both the CLI-args branch and the env branch.
- Error messages now use the generic label `time_range_minutes` so they read naturally for both `sys.argv[3]` and `TIME_RANGE_MINUTES`.
- No change to valid-input behaviour: `int(raw)` with `raw > 0` returns the same value as before.

### Extra

No new dependencies.

## Checklist

- [x] I have run application tests ensuring nothing has broken.
- [x] I have updated the documentation if required. (No user-visible docs change; error strings only.)
- [x] I have added tests which cover my changes.

### Testing

- Added `tests/test_run_args.py` covering: valid input, non-integer input, zero, negatives, and a round-trip through `_load_request_from_args_or_env` for both failure modes and the happy path.
- Local run (`uv run pytest tests/`): **8 passed** (1 pre-existing + 7 new).
- `ruff check --config=ruff.toml` and `ruff format --config=ruff.toml --check`: clean.
- `uv run mypy --config-file=mypy.ini $(find src/sre_agent -name '*.py')`: `Success: no issues found in 94 source files`.

## Type of change

Bug fix.
